### PR TITLE
Modal search > use aria-hidden technique

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1932,9 +1932,9 @@
       }
     },
     "@stormid/modal": {
-      "version": "1.0.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@stormid/modal/-/modal-1.0.0-alpha.8.tgz",
-      "integrity": "sha512-7aVj+DEOrUCQ+2NBWOUOyPeUgpyu28qv1xlsbY30ftSmbeN9FyyZGJqnFfO/V/zUsKjBgMIxnV8LNeRUYd+Ctw=="
+      "version": "1.0.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@stormid/modal/-/modal-1.0.0-alpha.10.tgz",
+      "integrity": "sha512-Isdd0N9cAtn5l4jjdBMh4v4f7dcbzitaQVHXCm9RG1+HZ4hDLfsOThFGXvaWrkGl/37RQombfw3i6b4M3UIczg=="
     },
     "@stormid/outliner": {
       "version": "1.0.0-alpha.4",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "@stormid/cookie-banner": "^1.0.0-alpha.15",
-    "@stormid/modal": "^1.0.0-alpha.8",
+    "@stormid/modal": "^1.0.0-alpha.10",
     "@stormid/outliner": "^1.0.0-alpha.4",
     "@stormid/tabs": "^1.0.0-alpha.4",
     "@stormid/toggle": "^1.0.0-alpha.10",

--- a/src/templates/pages/patterns/modal-search/index.js
+++ b/src/templates/pages/patterns/modal-search/index.js
@@ -31,8 +31,8 @@ modal('.js-modal-search');
         <li class="list-item">Modal should be hidden visually and from accessibility tree when closed</li>
         <li class="list-item">Modal should be visible and in accessibility tree when open</li>
         <li class="list-item">Modal should be labelled with either an aria-label or an aria-labelledby that points to a visible title</li>
-        <li class="list-item">An element within modal should be given focus when open</li>
-        <li class="list-item">Modal should either have an aria-modal attribute or the background (rest of the page) must get an aria-hidden attribute when the modal is open</li>
+        <li class="list-item">An element within the modal should be given focus when open</li>
+        <li class="list-item">When the modal is open the background (rest of the elements on the page) must get an aria-hidden attribute</li>
         <li class="list-item">Modal must trap tab when open</li>
         <li class="list-item">Tab sequence in the modal should include a visible button that closes the dialog</li>
         <li class="list-item">Search input should be appropriately labelled</li>


### PR DESCRIPTION
Update to use aria-hidden technique for modal described in https://github.com/stormid/ui-patterns/issues/2 and implemented in https://github.com/stormid/components/issues/168.