### PR TITLE
Prevent background scroll when modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1932,9 +1932,9 @@
       }
     },
     "@stormid/modal": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@stormid/modal/-/modal-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-Isdd0N9cAtn5l4jjdBMh4v4f7dcbzitaQVHXCm9RG1+HZ4hDLfsOThFGXvaWrkGl/37RQombfw3i6b4M3UIczg=="
+      "version": "1.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@stormid/modal/-/modal-1.0.0-alpha.11.tgz",
+      "integrity": "sha512-t48Ggfzfzd0kyXCGNUOcs+qy+z3hTJ6zNNrJfagzy+G4K/9K5fbBWUQMl5QWINlpeZFQbyHUMPLq8b36QcHelA=="
     },
     "@stormid/outliner": {
       "version": "1.0.0-alpha.4",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "@stormid/cookie-banner": "^1.0.0-alpha.15",
-    "@stormid/modal": "^1.0.0-alpha.10",
+    "@stormid/modal": "^1.0.0-alpha.11",
     "@stormid/outliner": "^1.0.0-alpha.4",
     "@stormid/tabs": "^1.0.0-alpha.4",
     "@stormid/toggle": "^1.0.0-alpha.10",

--- a/src/css/components/_modal-search.scss
+++ b/src/css/components/_modal-search.scss
@@ -100,3 +100,6 @@
             border-radius: 0;
         }
 }
+.is--modal {
+    overflow: hidden;
+}

--- a/src/templates/pages/patterns/modal-confirmation/index.js
+++ b/src/templates/pages/patterns/modal-confirmation/index.js
@@ -34,6 +34,7 @@ modal('.js-modal-confirmation);
         <li class="list-item">Alertdialog should have a description - an aria-describedby attirbute that points to a visible description</li>
         <li class="list-item">An element within modal should be given focus when open</li>
         <li class="list-item">When the modal is open the background (rest of the elements on the page) must get an aria-hidden attribute</li>
+        <li class="list-item">When the modal is open the background document must not be scrollable, and the original scroll position must be restored when the modal is closed</li>
         <li class="list-item">Modal must trap tab when open</li>
         <li class="list-item">Tab sequence in the modal should include a visible button that closes the alertdialog</li>
         <li class="list-item">Search input should be appropriately labelled</li>

--- a/src/templates/pages/patterns/modal-search/index.js
+++ b/src/templates/pages/patterns/modal-search/index.js
@@ -33,6 +33,7 @@ modal('.js-modal-search');
         <li class="list-item">Modal should be labelled with either an aria-label or an aria-labelledby that points to a visible title</li>
         <li class="list-item">An element within the modal should be given focus when open</li>
         <li class="list-item">When the modal is open the background (rest of the elements on the page) must get an aria-hidden attribute</li>
+        <li class="list-item">When the modal is open the background document must not be scrollable, and the original scroll position must be restored when the modal is closed</li>
         <li class="list-item">Modal must trap tab when open</li>
         <li class="list-item">Tab sequence in the modal should include a visible button that closes the dialog</li>
         <li class="list-item">Search input should be appropriately labelled</li>


### PR DESCRIPTION
Addresses #3.

- Updates to most recent modal component with CSS className hook for scroll prevention
- Adds is-modal scroll prevention CSS to examples
- Adds AC to modal patterns