### PR TITLE
Feature/ax updates

### DIFF
--- a/__tests__/patterns/expandable-navigation/index.js
+++ b/__tests__/patterns/expandable-navigation/index.js
@@ -33,7 +33,7 @@ describe('Expandable navigation > mark up', () => {
 
     it('Buttons should be appropriately labelled', () => {
         const toggleButton = document.querySelector('.expandable-nav__btn');
-        expect(toggleButton.getAttribute('aria-label')).toEqual('Show or hide navigation menu');
+        expect(toggleButton.getAttribute('aria-label')).toEqual('Show navigation menu');
     });
 
     it('Active navigation link should have ARIA current attribute', () => {
@@ -127,9 +127,16 @@ describe('Expandable navigation > axe > ARIA', () => {
 
     it('ARIA expanded attribute should correctly describe shown/hidden state', () => {
         const [ toggle ] = instance.getState().toggles;
-        expect(toggle.getAttribute('aria-expanded')).toEqual("false");
+        expect(toggle.getAttribute('aria-expanded')).toEqual('false');
         instance.toggle();
-        expect(toggle.getAttribute('aria-expanded')).toEqual("true");
+        expect(toggle.getAttribute('aria-expanded')).toEqual('true');
+    });
+
+    it('ARIA label attribute should correctly describe shown/hidden statec', () => {
+        const [ toggle ] = instance.getState().toggles;
+        if (toggle.hasAttribute('data-show-label')) expect(toggle.getAttribute('aria-label')).toEqual(toggle.getAttribute('data-show-label'));
+        instance.toggle();
+        if (toggle.hasAttribute('data-hide-label')) expect(toggle.getAttribute('aria-label')).toEqual(toggle.getAttribute('data-hide-label'));
     });
 
 });

--- a/src/css/components/_expandable-navigation.scss
+++ b/src/css/components/_expandable-navigation.scss
@@ -48,11 +48,6 @@
     border-bottom: 1px solid var(--dark-grey-3);
     transition: background-color 120ms ease;
     text-decoration: none;
-
-    &.is--active {
-        background-color: var(--dark-grey-3);
-    }
-
     &:focus {
         border: 1px solid var(--highlight);
     }

--- a/src/css/components/_full-screen-navigation.scss
+++ b/src/css/components/_full-screen-navigation.scss
@@ -94,6 +94,7 @@
         bottom: 0;
         right: 0;
         background-color: var(--off-black);
+        overflow: auto;
     }
 
     .full-screen-nav__btn,
@@ -104,7 +105,7 @@
 }
 
 .full-screen-navigation__close {
-    position: fixed;
+    position: absolute;
     color: white;
     top: var(--baseline);
     right: var(--gutter);

--- a/src/css/components/_main.scss
+++ b/src/css/components/_main.scss
@@ -1,0 +1,9 @@
+.main {
+    padding: var(--baseline);
+
+    h1 {
+        font-size: var(--font-size-plus-1);
+        font-weight: var(--semibold-weight);
+        margin-bottom: var(--baseline);
+    }
+}

--- a/src/js/modules/expandable-navigation/index.js
+++ b/src/js/modules/expandable-navigation/index.js
@@ -1,7 +1,9 @@
 import toggle from '@stormid/toggle';
 const SELECTOR = '.js-expandable-nav';
-const SHOW_LABEL = 'data-show-label';
-const HIDE_LABEL = 'data-hide-label';
+const SHOW_LABEL_ATTRIBUTE = 'data-show-label';
+const HIDE_LABEL_ATTRIBUTE = 'data-hide-label';
+const SHOW_LABEL_DEFAULT = "Show navigation menu";
+const HIDE_LABEL_DEFAULT = "Hide navigation menu";
 
 export const init = () => {
     if (document.querySelector(SELECTOR)) {
@@ -9,9 +11,11 @@ export const init = () => {
 
         const toggleAriaLabel = e => {
             const { toggles } = e.detail.getState();
+
             toggles.forEach((btn) => {
-                let newLabel = (btn.getAttribute('aria-expanded') === "true") ? btn.getAttribute(HIDE_LABEL) : btn.getAttribute(SHOW_LABEL);
-                if(newLabel) btn.setAttribute('aria-label', newLabel);
+                const isExpanded = btn.getAttribute('aria-expanded') === "true";
+                let newLabel = (isExpanded) ? btn.getAttribute(HIDE_LABEL_ATTRIBUTE) : btn.getAttribute(SHOW_LABEL_ATTRIBUTE);
+                btn.setAttribute('aria-label', (newLabel) ? newLabel : (isExpanded) ? HIDE_LABEL_DEFAULT : SHOW_LABEL_DEFAULT);
             });
         }
     

--- a/src/js/modules/expandable-navigation/index.js
+++ b/src/js/modules/expandable-navigation/index.js
@@ -2,25 +2,23 @@ import toggle from '@stormid/toggle';
 const SELECTOR = '.js-expandable-nav';
 const SHOW_LABEL_ATTRIBUTE = 'data-show-label';
 const HIDE_LABEL_ATTRIBUTE = 'data-hide-label';
-const SHOW_LABEL_DEFAULT = "Show navigation menu";
-const HIDE_LABEL_DEFAULT = "Hide navigation menu";
 
 export const init = () => {
     if (document.querySelector(SELECTOR)) {
-        var toggleInstances = toggle(SELECTOR, { focus: false });
-
+        const toggleInstances = toggle(SELECTOR, { focus: false });
         const toggleAriaLabel = e => {
             const { toggles } = e.detail.getState();
 
-            toggles.forEach((btn) => {
-                const isExpanded = btn.getAttribute('aria-expanded') === "true";
-                let newLabel = (isExpanded) ? btn.getAttribute(HIDE_LABEL_ATTRIBUTE) : btn.getAttribute(SHOW_LABEL_ATTRIBUTE);
-                btn.setAttribute('aria-label', (newLabel) ? newLabel : (isExpanded) ? HIDE_LABEL_DEFAULT : SHOW_LABEL_DEFAULT);
+            toggles.forEach(btn => {
+                if (!btn.hasAttribute(SHOW_LABEL_ATTRIBUTE) && !!btn.hasAttribute(SHOW_LABEL_ATTRIBUTE)) return;
+                btn.setAttribute('aria-label', (btn.getAttribute('aria-expanded') === 'true') ? btn.getAttribute(HIDE_LABEL_ATTRIBUTE) : btn.getAttribute(SHOW_LABEL_ATTRIBUTE));
             });
-        }
-    
-        document.addEventListener('toggle.open', toggleAriaLabel);
-        document.addEventListener('toggle.close', toggleAriaLabel);
+        };
+
+        toggleInstances.forEach(instance => {
+            instance.getState().node.addEventListener('toggle.open', toggleAriaLabel);
+            instance.getState().node.addEventListener('toggle.close', toggleAriaLabel);
+        });
 
         return toggleInstances;
     }

--- a/src/js/modules/expandable-navigation/index.js
+++ b/src/js/modules/expandable-navigation/index.js
@@ -1,8 +1,25 @@
 import toggle from '@stormid/toggle';
 const SELECTOR = '.js-expandable-nav';
+const SHOW_LABEL = 'data-show-label';
+const HIDE_LABEL = 'data-hide-label';
 
 export const init = () => {
-    if (document.querySelector(SELECTOR)) return toggle(SELECTOR, { focus: false });
+    if (document.querySelector(SELECTOR)) {
+        var toggleInstances = toggle(SELECTOR, { focus: false });
+
+        const toggleAriaLabel = e => {
+            const { toggles } = e.detail.getState();
+            toggles.forEach((btn) => {
+                let newLabel = (btn.getAttribute('aria-expanded') === "true") ? btn.getAttribute(HIDE_LABEL) : btn.getAttribute(SHOW_LABEL);
+                if(newLabel) btn.setAttribute('aria-label', newLabel);
+            });
+        }
+    
+        document.addEventListener('toggle.open', toggleAriaLabel);
+        document.addEventListener('toggle.close', toggleAriaLabel);
+
+        return toggleInstances;
+    }
 };
 
 init();

--- a/src/templates/pages/example/exclusive-toggles/index.js
+++ b/src/templates/pages/example/exclusive-toggles/index.js
@@ -6,8 +6,9 @@ export const title = 'Exclusive toggles example';
 
 const ExclusiveToggles = () => <ExampleLayout>
     <Code />
-    <main tabindex="0" aria-label="Next focusable item on the page">
-
+    <main class="main">
+        <h1>Lorem ipsum</h1>
+        <p>Duis pulvinar ipsum in lorem maximus faucibus. Maecenas pharetra placerat ex, id elementum felis dignissim sed. <a href="#">Fusce gravida</a> sit amet sapien in interdum. Nam id leo gravida eros gravida elementum. Nulla eu dui posuere, efficitur tellus id, dapibus dolor. Duis tincidunt metus sed condimentum pharetra. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer ullamcorper, nibh vel finibus rutrum, urna augue ultricies velit, sed feugiat metus felis in libero.</p>
     </main>
 </ExampleLayout>;
 

--- a/src/templates/pages/example/expandable-navigation/code.js
+++ b/src/templates/pages/example/expandable-navigation/code.js
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 
 const Code = () => <nav class="expandable-nav__nav" aria-label={'Primary navigation'}>
-    <button type="button" class="expandable-nav__btn js-expandable-nav__toggle" aria-label="Show or hide navigation menu" aria-controls="expandable-nav" aria-expanded="false">
+    <button type="button" class="expandable-nav__btn js-expandable-nav__toggle" aria-label="Show navigation menu" aria-controls="expandable-nav" aria-expanded="false" data-show-label="Show navigation menu" data-hide-label="Hide navigation menu">
         <svg focusable="false" class="expandable-nav__btn-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
             <path d="M0 0h24v24H0z" fill="none" />
             <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" />

--- a/src/templates/pages/example/expandable-search/code.js
+++ b/src/templates/pages/example/expandable-search/code.js
@@ -5,7 +5,7 @@ const Code = () => <div class="expandable-search__container">
         <svg class="expandable-search__btn-icon" focusable="false" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#fff"><path d="M0 0h24v24H0z" fill="none"/><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
     </button>
     <div class="expandable-search js-expandable-search" id="expandable-search" data-toggle="js-expandable-search__btn">
-        <form class="expandable-search__form" action="#">
+        <form class="expandable-search__form" action="#" role="search">
             <label class="expandable-search__label" for="q">Your search</label>
             <input class="expandable-search__input" type="search" id="q" name="q" />
             <button class="expandable-search__submit">search</button>

--- a/src/templates/pages/example/expandable-search/index.js
+++ b/src/templates/pages/example/expandable-search/index.js
@@ -8,8 +8,9 @@ const ExpandableSearch = () => <ExampleLayout>
     <header class="expandable-search__header">
         <Code />
     </header>
-    <main tabindex="0" aria-label="Next focusable item on the page">
-
+    <main class="main">
+        <h1>Lorem ipsum</h1>
+        <p>Duis pulvinar ipsum in lorem maximus faucibus. Maecenas pharetra placerat ex, id elementum felis dignissim sed. <a href="#">Fusce gravida</a> sit amet sapien in interdum. Nam id leo gravida eros gravida elementum. Nulla eu dui posuere, efficitur tellus id, dapibus dolor. Duis tincidunt metus sed condimentum pharetra. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer ullamcorper, nibh vel finibus rutrum, urna augue ultricies velit, sed feugiat metus felis in libero.</p>
     </main>
 </ExampleLayout>;
 

--- a/src/templates/pages/example/full-screen-navigation/index.js
+++ b/src/templates/pages/example/full-screen-navigation/index.js
@@ -10,8 +10,9 @@ const ModalFullScreenNav = () => <ExampleLayout>
             <Code />
         </div>
     </header>
-    <main tabindex="0" aria-label="Next focusable item on the page">
-
+    <main class="main">
+        <h1>Lorem ipsum</h1>
+        <p>Duis pulvinar ipsum in lorem maximus faucibus. Maecenas pharetra placerat ex, id elementum felis dignissim sed. <a href="#">Fusce gravida</a> sit amet sapien in interdum. Nam id leo gravida eros gravida elementum. Nulla eu dui posuere, efficitur tellus id, dapibus dolor. Duis tincidunt metus sed condimentum pharetra. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer ullamcorper, nibh vel finibus rutrum, urna augue ultricies velit, sed feugiat metus felis in libero.</p>
     </main>
 </ExampleLayout>;
 

--- a/src/templates/pages/example/modal-confirmation/code.js
+++ b/src/templates/pages/example/modal-confirmation/code.js
@@ -2,7 +2,7 @@ import { h, Fragment } from 'preact';
 
 const Code = () => <Fragment>
     <button type="button" class="modal-confirmation__btn js-modal-confirmation__btn">Delete</button>
-    <div id="modal-confirmation" class="js-modal-confirmation modal-confirmation modal-container" data-modal-toggle="js-modal-confirmation__btn">
+    <div id="modal-confirmation" role="region" class="js-modal-confirmation modal-confirmation modal-container" data-modal-toggle="js-modal-confirmation__btn">
         <div class="modal" role="alertdialog" aria-labelledby="modal-label" aria-describedby="modal-description">
             <h1 class="modal-confirmation__title" id="modal-label">Are you sure?</h1>
             <form class="modal__form modal-confirmation__form" action="#">

--- a/src/templates/pages/example/modal-search/code.js
+++ b/src/templates/pages/example/modal-search/code.js
@@ -8,7 +8,7 @@ const Code = () => <Fragment>
     <div id="modal-search" class="js-modal-search modal-container" data-modal-toggle="js-modal-search__btn" hidden>
         <div class="modal" role="dialog" aria-labelledby="modal-title">
             <h2 id="modal-title" class="modal__title">Search this site</h2>
-            <form class="modal__form" action="#">
+            <form class="modal__form" action="#" role="search">
                 <label class="modal__label" for="q">Your search</label>
                 <input class="modal__input" type="search" id="q" name="q" />
                 <button class="modal__search-btn">search</button>

--- a/src/templates/pages/example/modal-search/code.js
+++ b/src/templates/pages/example/modal-search/code.js
@@ -5,7 +5,7 @@ const Code = () => <Fragment>
         <svg class="modal-search__btn-icon" focusable="false" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#fff"><path d="M0 0h24v24H0z" fill="none"/><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
         search
     </button>
-    <div id="modal-search" class="js-modal-search modal-container" data-modal-toggle="js-modal-search__btn" hidden>
+    <div id="modal-search" role="region" class="js-modal-search modal-container" data-modal-toggle="js-modal-search__btn" hidden>
         <div class="modal" role="dialog" aria-labelledby="modal-title">
             <h2 id="modal-title" class="modal__title">Search this site</h2>
             <form class="modal__form" action="#" role="search">

--- a/src/templates/pages/example/modal-search/index.js
+++ b/src/templates/pages/example/modal-search/index.js
@@ -10,8 +10,9 @@ const ModalSearch = () => <ExampleLayout>
             <Code />
         </div>
     </header>
-    <main tabindex="0" aria-label="Next focusable item on the page">
-
+    <main class="main">
+        <h1>Lorem ipsum</h1>
+        <p>Duis pulvinar ipsum in lorem maximus faucibus. Maecenas pharetra placerat ex, id elementum felis dignissim sed. <a href="#">Fusce gravida</a> sit amet sapien in interdum. Nam id leo gravida eros gravida elementum. Nulla eu dui posuere, efficitur tellus id, dapibus dolor. Duis tincidunt metus sed condimentum pharetra. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer ullamcorper, nibh vel finibus rutrum, urna augue ultricies velit, sed feugiat metus felis in libero.</p>
     </main>
 </ExampleLayout>;
 

--- a/src/templates/pages/patterns/expandable-navigation/index.js
+++ b/src/templates/pages/patterns/expandable-navigation/index.js
@@ -28,7 +28,22 @@ const ExpandableNavigation = () => <PatternLayout>
     <pre class="pre"><code class="code">{`${render(<Code />, null, { pretty: true })}`}</code></pre>
     <pre class="pre"><code class="code">{`import toggle from '@stormid/toggle';
 
-toggle('.js-expandable-nav', { focus: false });`}</code></pre>
+const toggleInstances = toggle('.js-expandable-nav', { focus: false });
+
+//to change the aria-label when navigation is toggled
+const SHOW_LABEL_ATTRIBUTE = 'data-show-label';
+const HIDE_LABEL_ATTRIBUTE = 'data-hide-label';
+const toggleAriaLabel = e => {
+    const { toggles } = e.detail.getState();
+    toggles.forEach(btn => {
+        if (!btn.hasAttribute(SHOW_LABEL_ATTRIBUTE) && !!btn.hasAttribute(SHOW_LABEL_ATTRIBUTE)) return;
+        btn.setAttribute('aria-label', (btn.getAttribute('aria-expanded') === 'true') ? btn.getAttribute(HIDE_LABEL_ATTRIBUTE) : btn.getAttribute(SHOW_LABEL_ATTRIBUTE));
+    });
+};
+toggleInstances.forEach(instance => {
+    instance.getState().node.addEventListener('toggle.open', toggleAriaLabel);
+    instance.getState().node.addEventListener('toggle.close', toggleAriaLabel);
+});`}</code></pre>
     <h2 class="push-bottom plus-2 medium">Acceptance criteria</h2>
     <p class="push-bottom--double">The following is a list of example acceptance criteria to test against when using this pattern.  These critera should test that the specific markup requirements are met, and that the navigation behaves visually and functionally as expected.</p>
 
@@ -39,14 +54,15 @@ toggle('.js-expandable-nav', { focus: false });`}</code></pre>
         <li class="list-item">The navigation should be labelled appropriately to describe its function (e.g. 'Primary Navigation').  This can be done by an HTML heading element being the first item in the navigation, or an <pre class="pre--inline">aria-label</pre> on the <pre class="pre--inline">&lt;nav&gt;</pre> element itself</li>
         <li class="list-item">Buttons should be contained within the <pre class="pre--inline">&lt;nav&gt;</pre> element</li>
         <li class="list-item">An <pre class="pre--inline">aria-expanded</pre> attribute should be present on the toggle <pre class="pre--inline">&lt;button&gt;</pre>.  The value of this should be 'true' when the navigation is visible, and 'false' when the navigation is hidden.</li>
-        <li class="list-item">The toggle <pre class="pre--inline">&lt;button&gt;</pre> element should have an <pre class="pre--inline">aria-controls</pre> attribute.  The value of this should match the ID of the element being shown/hidden.</li>
+        <li class="list-item">The toggle <pre class="pre--inline">&lt;button&gt;</pre> element should have an <pre class="pre--inline">aria-controls</pre> attribute. The value of this should match the ID of the element being shown/hidden.</li>
         <li class="list-item">The currently active navigation link should have <pre class="pre--inline">aria-current</pre> attribute with its value set to 'page'</li>
+        <li class="list-item">Navigation toggle button labels that describe the state of the navigationshould update when toggled, e.g. 'Open' should change to 'Close'.</li>
     </ul>
 
     <h3 class="push-bottom--half plus-1 medium">For visual validation</h3>
     <ul class="list list--tick push-bottom--double">
         <li class="list-item">Navigation toggle buttons should have a clearly visible focus style which meets accessibility contrast requirements</li>
-        <li class="list-item">Navigation toggle buttons should be appropriately labelled to describe their functionality.  If the design requires no visible text, a label should be added as an <pre class="pre--inline">aria-label</pre> attribute on the <pre class="pre--inline">&lt;button&gt;</pre> element</li>
+        <li class="list-item">Navigation toggle buttons should be appropriately labelled to describe their functionality. If the design requires no visible text, a label should be added as an <pre class="pre--inline">aria-label</pre> attribute on the <pre class="pre--inline">&lt;button&gt;</pre> element</li>
         <li class="list-item">Navigation toggle buttons should be no less than 44px x 44px in size</li>
         <li class="list-item">Navigation links should be hidden visually, hidden from keyboard access, and not read by screenreaders when the menu is closed</li>
         <li class="list-item">Navigation links should be visible, available for keyboard access, and read by screenreaders when the menu is opened</li>

--- a/src/templates/pages/patterns/expandable-navigation/index.js
+++ b/src/templates/pages/patterns/expandable-navigation/index.js
@@ -59,7 +59,7 @@ toggle('.js-expandable-nav', { focus: false });`}</code></pre>
     <ul class="list list--tick push-bottom--double">
         <li class="list-item">Navigation toggle buttons should be available to be tabbed to and activated via keyboard</li>
         <li class="list-item">Navigation links should be available to be tabbed to and activated via keyboard</li>
-        <li class="list-item">The first navigation link should receive visible focus when navigation is opened</li>
+        <li class="list-item">The close button should receive visible focus when navigation is opened</li>
         <li class="list-item">When open, the navigation should not trap tab - a user should be able to tab out of the menu to page content below</li>
     </ul>
     <h2 class="push-bottom--half plus-1 medium">References</h2>

--- a/src/templates/pages/patterns/modal-confirmation/index.js
+++ b/src/templates/pages/patterns/modal-confirmation/index.js
@@ -40,6 +40,7 @@ modal('.js-modal-confirmation);
         <li class="list-item">The confirmation modal should be an HTML element with a <pre class="pre--inline">role="alertdialog"</pre> attribute. This element must contain everything that's visible within the modal when it opens</li>
         <li class="list-item">The confirmation modal element should either have an <pre class="pre--inline">aria-describedby</pre> attribute which describes the content, or an <pre class="pre--inline">aria-labelledby</pre> attribute that points to a visible <pre class="pre--inline">&lt;h2&gt;</pre> element with a matching ID</li>
         <li class="list-item">The confirmation modal element should have an <pre class="pre--inline">aria-describedby</pre> attribute that points to a visible element with a matching ID that describes the modal content</li>
+        <li class="list-item">The element containing the modal should have a role="region" attribute (or be another valid landmark element), so that the modal can be contained within a valid page landmark when moved into position</li>
     </ul>
 
     <h3 class="push-bottom--half plus-1 medium">For visual validation</h3>

--- a/src/templates/pages/patterns/modal-search/index.js
+++ b/src/templates/pages/patterns/modal-search/index.js
@@ -39,6 +39,7 @@ modal('.js-modal-search');
         <li class="list-item">An HTML <pre class="pre--inline">&lt;button&gt;</pre> element is used to close the search</li>
         <li class="list-item">The search modal should be an HTML element with a <pre class="pre--inline">role="dialog"</pre> attribute. This element must contain everything that's visible within the modal when it opens</li>
         <li class="list-item">The search modal element should either have an <pre class="pre--inline">aria-label</pre> attribute which titles the content, or an <pre class="pre--inline">aria-labelledby</pre> attribute that points to a visible <pre class="pre--inline">&lt;h2&gt;</pre> element with a matching ID</li>
+        <li class="list-item">The element containing the modal should have a role="region" attribute (or be another valid landmark element), so that the modal can be contained within a valid page landmark when moved into position</li>
     </ul>
 
     <h3 class="push-bottom--half plus-1 medium">For visual validation</h3>


### PR DESCRIPTION
Various AX fixes, bundled into one PR as most are small.  

**#55  - Expandable navigation - focus position**
- Updated AC to match functionality.  
- Maybe a wee bit of design input needed to think of a better way to show the 'active' link so that it's not confused with focus.  Or maybe we don't need to show that at all.

**#56  - Tabbable main element is confusing on example page**
- Removed tab index and added some sample content with link instead.

**#57 - Full screen navigation > landscape mobile overflow hidden**
- CSS overflow fix added

**#58 - Use search landmark on search patterns**
- role="search" added to search forms

**#61 - Modal should be contained in a landmark**
- Added a role="region" to both and updated ACs.  I did the same for both as the form already had a role="search" applied from #58 and didn't want to nest them?

**#54  - Expandable navigation - NVDA**
- This was the biggest update.  Gov.uk are achiving this by toggling the aria-label when the button is used.  Prior to this, our button's aria label was announced when landing on the button, but never -re-read as the button was used.  NVDA will now read out an updated label when the button is pressed, but I'm not sure what thoughts are on this?  Whether it might cause issues elsewhere?