### PR TITLE
Adds aria-haspopup and appropriate roles

### DIFF
--- a/__tests__/patterns/modal-confirmation/index.js
+++ b/__tests__/patterns/modal-confirmation/index.js
@@ -43,9 +43,9 @@ describe('Modal confirmation > mark up', () => {
         expect(toggleButton.textContent).toEqual('Delete');
     });
 
-    it('Modal should have a role of alertdialog', () => {
+    it('Modal should have a role of dialog', () => {
         const modal = document.querySelector('.modal');
-        expect(modal.getAttribute('role')).toEqual('alertdialog');
+        expect(modal.getAttribute('role')).toEqual('dialog');
     });
 
     it('Modal should be labelled with either an aria-label or an aria-labelledby that points to a visible title', () => {

--- a/src/templates/pages/example/exclusive-toggles/code.js
+++ b/src/templates/pages/example/exclusive-toggles/code.js
@@ -1,14 +1,14 @@
 import { h, Fragment } from 'preact';
 
 export const ExpandableNav = () => <nav class="exclusive-nav__container" aria-label={'Primary navigation'}>
-    <button class="exclusive-nav__btn js-exclusive-nav__toggle" aria-label="Show or hide navigation menu" aria-controls="exclusive-nav" aria-expanded="false">
+    <button class="exclusive-nav__btn js-exclusive-nav__toggle" aria-label="Show or hide navigation menu" aria-controls="exclusive-nav" aria-expanded="false" aria-haspopup="menu">
         <svg focusable="false" class="expandable-nav__btn-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
             <path d="M0 0h24v24H0z" fill="none" />
             <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" />
         </svg>
         menu
     </button>
-    <div id="exclusive-nav" class="exclusive-nav__display-wrap js-exclusive-nav" data-toggle="js-exclusive-nav__toggle">
+    <div id="exclusive-nav" class="exclusive-nav__display-wrap js-exclusive-nav" data-toggle="js-exclusive-nav__toggle" role="menu">
         <ul class="exclusive-nav__list">
             <li class="exclusive-nav__item">
                 <a class={`exclusive-nav__link`} href={'#'} >Item 1</a>
@@ -30,10 +30,10 @@ export const ExpandableNav = () => <nav class="exclusive-nav__container" aria-la
 </nav>;
 
 export const OffCanvasSearch = () => <div class="exclusive-search__container">
-    <button class="exclusive-search__btn js-exclusive-search__btn" aria-label="Show or hide site search">
+    <button class="exclusive-search__btn js-exclusive-search__btn" aria-label="Show or hide site search" aria-haspopup="dialog">
         <svg class="exclusive-search__btn-icon" focusable="false" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#fff"><path d="M0 0h24v24H0z" fill="none"/><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
     </button>
-    <div class="exclusive-search js-exclusive-search" id="exclusive-search" data-toggle="js-exclusive-search__btn">
+    <div class="exclusive-search js-exclusive-search" id="exclusive-search" data-toggle="js-exclusive-search__btn" role="dialog">
         <form class="exclusive-search__form" action="#">
             <label class="exclusive-search__label" for="q">Input your search term</label>
             <input class="exclusive-search__input" type="search" id="q" name="q" />

--- a/src/templates/pages/example/exclusive-toggles/code.js
+++ b/src/templates/pages/example/exclusive-toggles/code.js
@@ -1,14 +1,14 @@
 import { h, Fragment } from 'preact';
 
 export const ExpandableNav = () => <nav class="exclusive-nav__container" aria-label={'Primary navigation'}>
-    <button class="exclusive-nav__btn js-exclusive-nav__toggle" aria-label="Show or hide navigation menu" aria-controls="exclusive-nav" aria-expanded="false" aria-haspopup="menu">
+    <button class="exclusive-nav__btn js-exclusive-nav__toggle" aria-label="Show or hide navigation menu" aria-controls="exclusive-nav" aria-expanded="false">
         <svg focusable="false" class="expandable-nav__btn-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
             <path d="M0 0h24v24H0z" fill="none" />
             <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" />
         </svg>
         menu
     </button>
-    <div id="exclusive-nav" class="exclusive-nav__display-wrap js-exclusive-nav" data-toggle="js-exclusive-nav__toggle" role="menu">
+    <div id="exclusive-nav" class="exclusive-nav__display-wrap js-exclusive-nav" data-toggle="js-exclusive-nav__toggle">
         <ul class="exclusive-nav__list">
             <li class="exclusive-nav__item">
                 <a class={`exclusive-nav__link`} href={'#'} >Item 1</a>
@@ -33,7 +33,7 @@ export const OffCanvasSearch = () => <div class="exclusive-search__container">
     <button class="exclusive-search__btn js-exclusive-search__btn" aria-label="Show or hide site search" aria-haspopup="dialog">
         <svg class="exclusive-search__btn-icon" focusable="false" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#fff"><path d="M0 0h24v24H0z" fill="none"/><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
     </button>
-    <div class="exclusive-search js-exclusive-search" id="exclusive-search" data-toggle="js-exclusive-search__btn" role="dialog">
+    <div class="exclusive-search js-exclusive-search" id="exclusive-search" data-toggle="js-exclusive-search__btn" role="dialog" aria-label="Site search">
         <form class="exclusive-search__form" action="#">
             <label class="exclusive-search__label" for="q">Input your search term</label>
             <input class="exclusive-search__input" type="search" id="q" name="q" />

--- a/src/templates/pages/example/full-screen-navigation/code.js
+++ b/src/templates/pages/example/full-screen-navigation/code.js
@@ -8,7 +8,7 @@ const Code = () => <nav aria-label={'Primary navigation'}>
         </svg>
         menu
     </button>
-    <div id="full-screen-navigation" class="js-full-screen-nav full-screen-nav" data-toggle="js-full-screen-nav__toggle" aria-role="menu">
+    <div id="full-screen-navigation" class="js-full-screen-nav full-screen-nav" data-toggle="js-full-screen-nav__toggle" role="menu">
         <ul class="wrap full-screen-nav__list">
             <li class="full-screen-nav__item">
                 <a class={`full-screen-nav__link`} href={'#'} >Item 1</a>

--- a/src/templates/pages/example/full-screen-navigation/code.js
+++ b/src/templates/pages/example/full-screen-navigation/code.js
@@ -1,14 +1,14 @@
 import { h } from 'preact';
 
 const Code = () => <nav aria-label={'Primary navigation'}>
-    <button type="button" class="full-screen-nav__btn js-full-screen-nav__toggle" aria-label="Open menu" aria-controls="full-screen-navigation" aria-expanded="false">
+    <button type="button" class="full-screen-nav__btn js-full-screen-nav__toggle" aria-label="Open menu" aria-controls="full-screen-navigation" aria-expanded="false" aria-haspopup="menu">
         <svg focusable="false" class="full-screen-nav__btn-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
             <path d="M0 0h24v24H0z" fill="none" />
             <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" />
         </svg>
         menu
     </button>
-    <div id="full-screen-navigation" class="js-full-screen-nav full-screen-nav" data-toggle="js-full-screen-nav__toggle">
+    <div id="full-screen-navigation" class="js-full-screen-nav full-screen-nav" data-toggle="js-full-screen-nav__toggle" aria-role="menu">
         <ul class="wrap full-screen-nav__list">
             <li class="full-screen-nav__item">
                 <a class={`full-screen-nav__link`} href={'#'} >Item 1</a>

--- a/src/templates/pages/example/full-screen-navigation/code.js
+++ b/src/templates/pages/example/full-screen-navigation/code.js
@@ -1,14 +1,14 @@
 import { h } from 'preact';
 
 const Code = () => <nav aria-label={'Primary navigation'}>
-    <button type="button" class="full-screen-nav__btn js-full-screen-nav__toggle" aria-label="Open menu" aria-controls="full-screen-navigation" aria-expanded="false" aria-haspopup="menu">
+    <button type="button" class="full-screen-nav__btn js-full-screen-nav__toggle" aria-label="Open menu" aria-controls="full-screen-navigation" aria-expanded="false">
         <svg focusable="false" class="full-screen-nav__btn-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
             <path d="M0 0h24v24H0z" fill="none" />
             <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" />
         </svg>
         menu
     </button>
-    <div id="full-screen-navigation" class="js-full-screen-nav full-screen-nav" data-toggle="js-full-screen-nav__toggle" role="menu">
+    <div id="full-screen-navigation" class="js-full-screen-nav full-screen-nav" data-toggle="js-full-screen-nav__toggle">
         <ul class="wrap full-screen-nav__list">
             <li class="full-screen-nav__item">
                 <a class={`full-screen-nav__link`} href={'#'} >Item 1</a>

--- a/src/templates/pages/example/modal-confirmation/code.js
+++ b/src/templates/pages/example/modal-confirmation/code.js
@@ -1,9 +1,9 @@
 import { h, Fragment } from 'preact';
 
 const Code = () => <Fragment>
-    <button type="button" class="modal-confirmation__btn js-modal-confirmation__btn">Delete</button>
+    <button type="button" class="modal-confirmation__btn js-modal-confirmation__btn" aria-haspopup="dialog">Delete</button>
     <div id="modal-confirmation" aria-labelledby="modal-label" role="region" class="js-modal-confirmation modal-confirmation modal-container" data-modal-toggle="js-modal-confirmation__btn">
-        <div class="modal" role="alertdialog" aria-labelledby="modal-label" aria-describedby="modal-description">
+        <div class="modal" role="dialog" aria-labelledby="modal-label" aria-describedby="modal-description">
             <h1 class="modal-confirmation__title" id="modal-label">Are you sure?</h1>
             <form class="modal__form modal-confirmation__form" action="#">
                 <p id="modal-description">This will permanently remove this item</p>

--- a/src/templates/pages/example/modal-search/code.js
+++ b/src/templates/pages/example/modal-search/code.js
@@ -5,7 +5,7 @@ const Code = () => <Fragment>
         <svg class="modal-search__btn-icon" focusable="false" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#fff"><path d="M0 0h24v24H0z" fill="none"/><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
         search
     </button>
-    <div aria-role="dialog" id="modal-search" role="region" aria-labelledby="modal-title" class="js-modal-search modal-container" data-modal-toggle="js-modal-search__btn" hidden>
+    <div role="dialog" id="modal-search" role="region" aria-labelledby="modal-title" class="js-modal-search modal-container" data-modal-toggle="js-modal-search__btn" hidden>
         <div class="modal" role="dialog" aria-labelledby="modal-title">
             <h2 id="modal-title" class="modal__title">Search this site</h2>
             <form class="modal__form" action="#" role="search">

--- a/src/templates/pages/example/modal-search/code.js
+++ b/src/templates/pages/example/modal-search/code.js
@@ -1,11 +1,11 @@
 import { h, Fragment } from 'preact';
 
 const Code = () => <Fragment>
-    <button type="button" class="modal-search__btn js-modal-search__btn" aria-label="Show or hide site search">
+    <button type="button" class="modal-search__btn js-modal-search__btn" aria-label="Show or hide site search" aria-haspopup="dialog">
         <svg class="modal-search__btn-icon" focusable="false" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#fff"><path d="M0 0h24v24H0z" fill="none"/><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
         search
     </button>
-    <div id="modal-search" role="region" aria-labelledby="modal-title" class="js-modal-search modal-container" data-modal-toggle="js-modal-search__btn" hidden>
+    <div aria-role="dialog" id="modal-search" role="region" aria-labelledby="modal-title" class="js-modal-search modal-container" data-modal-toggle="js-modal-search__btn" hidden>
         <div class="modal" role="dialog" aria-labelledby="modal-title">
             <h2 id="modal-title" class="modal__title">Search this site</h2>
             <form class="modal__form" action="#" role="search">

--- a/src/templates/pages/patterns/full-screen-navigation/index.js
+++ b/src/templates/pages/patterns/full-screen-navigation/index.js
@@ -42,7 +42,6 @@ toggle('.js-full-screen-navigation');
         <li class="list-item">The open and close <pre class="pre--inline">&lt;button&gt;</pre> elements should have an <pre class="pre--inline">aria-controls</pre> attribute.  The value of this should match the ID of the element being shown/hidden.</li>
         <li class="list-item">The navigation should be contained within an HTML <pre class="pre--inline">&lt;nav&gt;</pre> element</li>
         <li class="list-item">Buttons should be contained within the <pre class="pre--inline">&lt;nav&gt;</pre> element</li>
-        <li class="list-item">Buttons should have a <pre class="pre--inline">aria-haspopup="menu"</pre> attribute</li>
         <li class="list-item">The <pre class="pre--inline">&lt;div&gt;</pre> element containing the popup menu elements should <em>not</em> have a <pre class="pre--inline">role=menu</pre> attribute</li>
         <li class="list-item">The navigation should be labelled appropriately to describe its function (e.g. 'Primary Navigation').  This can be done by an HTML heading element being the first item in the navigation, or an <pre class="pre--inline">aria-label</pre> on the <pre class="pre--inline">&lt;nav&gt;</pre> element itself</li>
         <li class="list-item">The currently active navigation link should have <pre class="pre--inline">aria-current</pre> attribute with its value set to 'page'</li>

--- a/src/templates/pages/patterns/full-screen-navigation/index.js
+++ b/src/templates/pages/patterns/full-screen-navigation/index.js
@@ -42,7 +42,8 @@ toggle('.js-full-screen-navigation');
         <li class="list-item">The open and close <pre class="pre--inline">&lt;button&gt;</pre> elements should have an <pre class="pre--inline">aria-controls</pre> attribute.  The value of this should match the ID of the element being shown/hidden.</li>
         <li class="list-item">The navigation should be contained within an HTML <pre class="pre--inline">&lt;nav&gt;</pre> element</li>
         <li class="list-item">Buttons should be contained within the <pre class="pre--inline">&lt;nav&gt;</pre> element</li>
-        <li class="list-item">The <pre class="pre--inline">&lt;nav&gt;</pre> element should <em>not</em> have a <pre class="pre--inline">role=dialog</pre> attribute</li>
+        <li class="list-item">Buttons should have a <pre class="pre--inline">aria-haspopup="menu"</pre> attribute</li>
+        <li class="list-item">The <pre class="pre--inline">&lt;div&gt;</pre> element containing the popup menu elements should <em>not</em> have a <pre class="pre--inline">role=menu</pre> attribute</li>
         <li class="list-item">The navigation should be labelled appropriately to describe its function (e.g. 'Primary Navigation').  This can be done by an HTML heading element being the first item in the navigation, or an <pre class="pre--inline">aria-label</pre> on the <pre class="pre--inline">&lt;nav&gt;</pre> element itself</li>
         <li class="list-item">The currently active navigation link should have <pre class="pre--inline">aria-current</pre> attribute with its value set to 'page'</li>
     </ul>

--- a/src/templates/pages/patterns/modal-confirmation/index.js
+++ b/src/templates/pages/patterns/modal-confirmation/index.js
@@ -36,8 +36,9 @@ modal('.js-modal-confirmation);
     <h3 class="push-bottom--half plus-1 medium">For validation in developer tools / web inspector</h3>
     <ul class="list list--tick push-bottom--double">
         <li class="list-item">An HTML <pre class="pre--inline">&lt;button&gt;</pre> element is used to open the confirmation modal</li>
+        <li class="list-item">The opening <pre class="pre--inline">&lt;button&gt;</pre> element should have an <pre class="pre--inline">aria-haspopup="dialog"</pre> attribute</li>
         <li class="list-item">An HTML <pre class="pre--inline">&lt;button&gt;</pre> element is used to close the confirmation modal</li>
-        <li class="list-item">The confirmation modal should be an HTML element with a <pre class="pre--inline">role="alertdialog"</pre> attribute. This element must contain everything that's visible within the modal when it opens</li>
+        <li class="list-item">The confirmation modal should be an HTML element with a <pre class="pre--inline">role="dialog"</pre> attribute. This element must contain everything that's visible within the modal when it opens</li>
         <li class="list-item">The confirmation modal element should either have an <pre class="pre--inline">aria-describedby</pre> attribute which describes the content, or an <pre class="pre--inline">aria-labelledby</pre> attribute that points to a visible <pre class="pre--inline">&lt;h2&gt;</pre> element with a matching ID</li>
         <li class="list-item">The confirmation modal element should have an <pre class="pre--inline">aria-describedby</pre> attribute that points to a visible element with a matching ID that describes the modal content</li>
         <li class="list-item">The element containing the modal should have a role="region" attribute (or be another valid landmark element), so that the modal can be contained within a valid page landmark when moved into position</li>

--- a/src/templates/pages/patterns/modal-confirmation/index.js
+++ b/src/templates/pages/patterns/modal-confirmation/index.js
@@ -67,8 +67,7 @@ modal('.js-modal-confirmation);
     <h2 class="push-bottom--half plus-2 medium">References</h2>
     <ul class="list push-bottom--double">
         <li class="list-item"><a href="https://www.smashingmagazine.com/2018/01/friction-ux-design-tool/" rel="noopener nofollow">https://www.smashingmagazine.com/2018/01/friction-ux-design-tool/</a></li>
-        <li class="list-item"><a href="https://www.w3.org/TR/wai-aria-practices-1.1/#alertdialog" rel="noopener nofollow">https://www.w3.org/TR/wai-aria-practices-1.1/#alertdialog</a></li>
-        <li class="list-item"><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/alertdialog.html" rel="noopener nofollow">https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/alertdialog.html</a></li>
+        <li class="list-item"><a href="https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/" rel="noopener nofollow">https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/</a></li>
         <li class="list-item"><a href="https://webaim.org/standards/wcag/checklist" rel="noopener nofollow">https://webaim.org/standards/wcag/checklist</a></li>
     </ul>
 </PatternLayout>;

--- a/src/templates/pages/patterns/modal-search/index.js
+++ b/src/templates/pages/patterns/modal-search/index.js
@@ -46,9 +46,11 @@ modal('.js-modal-search');
     <ul class="list list--tick push-bottom--double">
         <li class="list-item">Search toggle buttons should have a clearly visible focus style which meets accessibility contrast requirements</li>
         <li class="list-item">Search toggle buttons should be appropriately labelled to describe their functionality.  If the design requires no visible text, a label should be added as an <pre class="pre--inline">aria-label</pre> attribute on the <pre class="pre--inline">&lt;button&gt;</pre> element</li>
+        <li class="list-item">Search toggle buttons should have an <pre class="pre--inline">aria-haspopup="dialog"</pre> attribute on the <pre class="pre--inline">&lt;button&gt;</pre> element</li>
         <li class="list-item">Search toggle buttons should be no less than 44px x 44px in size (unless any of the the allowed <a href="https://www.w3.org/TR/WCAG22/#target-size-enhanced">WCAG exceptions apply</a>)</li>
         <li class="list-item">The search form should be hidden visually, hidden from keyboard access, and not read by screen readers when the search is closed</li>
         <li class="list-item">The search form should be visible, available for keyboard access and read by screen readers when the search is opened</li>
+        <li class="list-item">The search modal should be an HTML element with a <pre class="pre--inline">role="dialog"</pre> attribute. This element must contain everything that's visible within the modal when it opens</li>
         <li class="list-item">Any form inputs within the search form should have a matching label describing its functionality. If the design does not use a visible label (for example, it may only ask for a placholder in the input itself) then the input should still be labelled either with an <pre class="pre--inline">aria-label</pre> attribute, or a visually hidden label</li>
         <li class="list-item">Any form inputs within the search form should have a clearly visible focus style which meets accessibility contrast requirements</li>
     </ul>


### PR DESCRIPTION
As per #28 

NVDA and Jaws have now fixed their implementation of aria-haspopup and the explicit definition of the various roles are now announced differently.  Therefore I have:

- added aria-haspopup="menu" to the fullpage nav pattern
- added aria-haspopup="dialog" to the modal confirmation pattern
- added aria-haspopup="dialog" to the modal search
- Added both nav and search from the above to the exlusive toggles pattern
- Updated ACs for the above

For modal confimation, the role has had to change from 'alertdialog' to the more generic 'dialog'.  This is because alertdialog is not supported as an option (yet) for haspopup.  

Although alertdialog is more specific for the confirm/cancel use case, NVDA did not announce any difference between this and the generic 'dialog' role when I tested it on the element.  

With the change to dialog, we can use the aria-haspopup attribute, and the 'opens dialog' message is announced on the button.  To me, this seemed more useful than keeping the existing 'alertdialog' role in place on the modal itself.