### PR TITLE
Feature/22 showmore

### DIFF
--- a/__tests__/patterns/show-more/index.js
+++ b/__tests__/patterns/show-more/index.js
@@ -1,0 +1,98 @@
+import { h } from 'preact';
+import { init as initShowMore, showMoreFocus } from '../../../src/js/modules/show-more';
+import ShowMore from '../../../src/templates/pages/example/show-more';
+import { render } from 'preact-render-to-string';
+
+describe('Show more > mark up', () => {
+    beforeAll(() => {
+        document.body.innerHTML = render(<ShowMore />);
+        initShowMore();
+    });
+
+    it('Should use a button element for the section trigger', () => {
+        const toggleButton = document.querySelector('.js-show-more__toggle');
+        expect(toggleButton.tagName).toEqual('BUTTON');
+    });
+
+    it('Buttons should be focusable', () => {
+        const toggleButton = document.querySelector('.js-show-more__toggle');
+        toggleButton.focus();
+        expect(document.activeElement).toEqual(toggleButton);
+    });
+
+    it('Buttons should be appropriately labelled', () => {
+        const toggleButton = document.querySelector('.js-show-more__toggle');
+        expect(toggleButton.getAttribute('aria-label')).toEqual('Show more about Lorem ipsum dolor sit amet');
+    });
+
+});
+
+describe('Show more > behaviour > keyboard', () => {
+    let instance;
+    beforeAll(() => {
+        document.body.innerHTML = render(<ShowMore />);
+        [ instance ] = initShowMore()[0];
+    });
+    afterEach(() => {
+        if (instance.getState().isOpen === true) instance.toggle();
+    });
+});
+
+describe('Show more > behaviour > focus management', () => {
+    let instance;
+    beforeAll(() => {
+        document.body.innerHTML = render(<ShowMore />);
+        [ instance ] = initShowMore()[0];
+    });
+
+    it('showMoreFocus should correctly manage focus position', () => {
+        const node = instance.getState().node;
+        const [ show ] = instance.getState().toggles;
+        expect(node.getAttribute('tabindex')).toBeNull();
+
+        instance.toggle();
+        showMoreFocus(instance.getState().isOpen, node, show);
+        expect(node.getAttribute('tabindex')).toEqual("-1");
+        expect(document.activeElement).toEqual(node);
+
+        instance.toggle();
+        showMoreFocus(instance.getState().isOpen, node, show);
+        expect(node.getAttribute('tabindex')).toEqual(null);
+        expect(document.activeElement).toEqual(show);
+    });
+
+    
+    // it('Focus should move appropriately when toggle buttons used', () => {
+    //     const node = instance.getState().node;
+    //     const [ show, hide ] = instance.getState().toggles;
+    //     show.click();
+    //     expect(document.activeElement).toEqual(node);
+    //     hide.click();
+    //     expect(document.activeElement).toEqual(show);
+    // });
+});
+
+describe('Show more > axe > ARIA', () => {
+    let instance;
+    beforeAll(() => {
+        document.body.innerHTML = render(<ShowMore />);
+        [ instance ] = initShowMore()[0];
+    });
+    afterEach(() => {
+        if (instance.getState().isOpen === true) instance.toggle();
+    });
+
+    it('ARIA controls attribute should correctly associate button with search container element', () => {
+        const { toggles, node } = instance.getState();
+        const [ toggle ] = toggles;
+        expect(toggle.getAttribute('aria-controls')).toEqual(node.getAttribute('id'));
+    });
+
+    it('ARIA expanded attribute should correctly describe shown/hidden state', () => {
+        const [ toggle ] = instance.getState().toggles;
+        expect(toggle.getAttribute('aria-expanded')).toEqual("false");
+        instance.toggle();
+        expect(toggle.getAttribute('aria-expanded')).toEqual("true");
+    });
+
+});

--- a/src/css/components/_form.scss
+++ b/src/css/components/_form.scss
@@ -211,6 +211,18 @@
     &:focus {
         outline: 4px solid var(--highlight);
     }
+
+    &--text {
+        padding: 0;
+        background: transparent;
+        font-size: var(--font-size-baseline);
+        font-weight: bold;
+
+        &:hover {
+            background-color: transparent;
+            text-decoration: underline;
+        }
+    }
 }
 
 // windows high contrast support 

--- a/src/css/components/_show-more.scss
+++ b/src/css/components/_show-more.scss
@@ -11,11 +11,31 @@
         margin-bottom: var(--baseline);
     }
 
+    &__btn, &__btn--hide {
+        line-height: 44px;      
+    }
+
     &__bd, &__btn--hide, &.is--active &__btn {
         display: none;
     }
 
-    &.is--active &__bd, &.is--active &__btn--hide {
+    &__bd {
+        opacity: 0;
+    }
+
+    &.is--active &__bd,  &.is--active &__btn--hide {
         display: block;
+        animation-name: fadein;
+        animation-duration: 0.75s;
+        animation-fill-mode: forwards; 
     }
 }
+
+@keyframes fadein {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }

--- a/src/css/components/_show-more.scss
+++ b/src/css/components/_show-more.scss
@@ -1,0 +1,21 @@
+.show-more {
+    padding-bottom: var(--baseline);
+
+    > * {
+        margin-bottom: calc(var(--baseline)/2);
+    }
+
+    &__heading {
+        font-size: var(--font-size-plus-2);
+        font-weight: 600;
+        margin-bottom: var(--baseline);
+    }
+
+    &__bd, &__btn--hide, &.is--active &__btn {
+        display: none;
+    }
+
+    &.is--active &__bd, &.is--active &__btn--hide {
+        display: block;
+    }
+}

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -36,3 +36,4 @@
 @import 'components/form';
 @import 'components/full-screen-navigation';
 @import 'components/heading-subheading';
+@import 'components/show-more';

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -8,6 +8,7 @@ import './modules/modal-confirmation';
 import './modules/cookie-banner';
 import './modules/form-validation';
 import './modules/tabs';
+import './modules/show-more';
 
 // Importer(`tabs`)()
 // import(/* webpackChunkName: "toggle" */`./features/toggle`).then(module => module.default());

--- a/src/js/modules/show-more/index.js
+++ b/src/js/modules/show-more/index.js
@@ -18,13 +18,7 @@ export const init = () => {
             focus: false, 
             local: true,
             callback: (tog) => {
-                if (tog.isOpen) {
-                    currentBlock.setAttribute('tabindex', '-1');
-                    currentBlock.focus();
-                } else {
-                    currentBlock.removeAttribute('tabindex', '-1');
-                    currentShowMore.focus();
-                }
+                if (!tog.isOpen) currentShowMore.focus();
             }
         });
     })

--- a/src/js/modules/show-more/index.js
+++ b/src/js/modules/show-more/index.js
@@ -5,9 +5,20 @@ const SELECTORS = {
     MORE_BTN: '.js-show-more__btn',
 }
 
+export const showMoreFocus = (isOpen, currentBlock, currentShowMore) => {
+    if (isOpen) {
+        currentBlock.setAttribute('tabindex', '-1');
+        currentBlock.focus();
+    } else {
+        currentBlock.removeAttribute('tabindex', '-1');
+        currentShowMore.focus();
+    }
+}
+
 export const init = () => {
 
     const nodes = Array.from(document.querySelectorAll(SELECTORS.NODE));
+    const initialised = [];
 
     nodes.forEach((node) => {
         const currentBlock = node.querySelector(SELECTORS.BLOCK);
@@ -17,12 +28,12 @@ export const init = () => {
         const showMoreToggle = toggle(currentBlock, { 
             focus: false, 
             local: true,
-            callback: (tog) => {
-                if (!tog.isOpen) currentShowMore.focus();
-            }
+            callback: (tog) => showMoreFocus(tog.isOpen, currentBlock, currentShowMore)
         });
+        initialised.push(showMoreToggle);
     })
 
+    return initialised;
 };
 
 init();

--- a/src/js/modules/show-more/index.js
+++ b/src/js/modules/show-more/index.js
@@ -1,0 +1,34 @@
+import toggle from '@stormid/toggle';
+const SELECTORS = {
+    NODE: '.js-show-more',
+    BLOCK: '.js-show-more__block',
+    MORE_BTN: '.js-show-more__btn',
+}
+
+export const init = () => {
+
+    const nodes = Array.from(document.querySelectorAll(SELECTORS.NODE));
+
+    nodes.forEach((node) => {
+        const currentBlock = node.querySelector(SELECTORS.BLOCK);
+        const currentShowMore = node.querySelector(SELECTORS.MORE_BTN);
+        if(!currentBlock || !currentShowMore) return;
+
+        const showMoreToggle = toggle(currentBlock, { 
+            focus: false, 
+            local: true,
+            callback: (tog) => {
+                if (tog.isOpen) {
+                    currentBlock.setAttribute('tabindex', '-1');
+                    currentBlock.focus();
+                } else {
+                    currentBlock.removeAttribute('tabindex', '-1');
+                    currentShowMore.focus();
+                }
+            }
+        });
+    })
+
+};
+
+init();

--- a/src/templates/pages/example/expandable-section/index.js
+++ b/src/templates/pages/example/expandable-section/index.js
@@ -4,11 +4,11 @@ import Code from './code';
 
 export const title = 'Expandable section example';
 
-const ModalSearch = () => <ExampleLayout>
+const ExpandableSection = () => <ExampleLayout>
     <main class="wrap soft-top">
         <h1 class="visuallyhidden">Expandable section example</h1>
         <Code />
     </main>
 </ExampleLayout>;
 
-export default ModalSearch;
+export default ExpandableSection;

--- a/src/templates/pages/example/show-more/code.js
+++ b/src/templates/pages/example/show-more/code.js
@@ -1,0 +1,23 @@
+import { h, Fragment } from 'preact';
+
+const Code = () => <Fragment>
+    <div class="show-more js-show-more">
+        <h2 class="show-more__heading">
+            Lorem ipsum dolor sit amet
+        </h2>
+        <p>Aenean id posuere nunc. Donec diam nisl, rhoncus vel faucibus sed, porttitor sit amet ipsum. Donec at venenatis augue. Phasellus consequat lectus non augue vestibulum, at varius diam sagittis. Morbi nec purus augue. Etiam rutrum ullamcorper arcu vitae sollicitudin. Aliquam bibendum suscipit risus, at lacinia tortor efficitur ac.</p>
+        <p>Praesent vitae mi nec mauris vehicula ultricies nec ut felis. Nam vel nisi id nunc efficitur fermentum. Vestibulum mollis enim nec ultrices mattis. Curabitur placerat sed nisl lobortis iaculis. Fusce porttitor massa augue, sit amet faucibus enim finibus nec. Maecenas hendrerit metus in justo commodo viverra.</p>
+        <button type="button" class="btn btn--text show-more__btn js-show-more__toggle js-show-more__btn" aria-expanded="false" aria-controls="more-content" aria-label="Show more about Lorem ipsum dolor sit amet">
+            Show more...
+        </button>
+        <div id="more-content" class="show-more__bd js-show-more__block" data-toggle="js-show-more__toggle">
+            <p>Aenean id posuere nunc. Donec diam nisl, <a href="#">rhoncus vel faucibus sed</a>, porttitor sit amet ipsum. Donec at venenatis augue. Phasellus consequat lectus non augue vestibulum, at varius diam sagittis. Morbi nec purus augue. Etiam rutrum ullamcorper arcu vitae sollicitudin. Aliquam bibendum suscipit risus, at lacinia tortor efficitur ac.</p>
+            <p>Praesent vitae mi nec mauris vehicula ultricies nec ut felis. Nam vel nisi id nunc efficitur fermentum. Vestibulum mollis enim nec ultrices mattis. Curabitur placerat sed nisl lobortis iaculis. Fusce porttitor massa augue, sit amet faucibus enim finibus nec. Maecenas hendrerit metus in justo commodo viverra.</p>
+        </div>
+        <button type="button" class="btn btn--text show-more__btn--hide js-show-more__toggle js-show-more__btn-hide" aria-expanded="false" aria-controls="more-content" aria-label="Show less about Lorem ipsum dolor sit amet">
+            Show less ^
+        </button>
+    </div>
+</Fragment>;
+
+export default Code;

--- a/src/templates/pages/example/show-more/code.js
+++ b/src/templates/pages/example/show-more/code.js
@@ -6,7 +6,6 @@ const Code = () => <Fragment>
             Lorem ipsum dolor sit amet
         </h2>
         <p>Aenean id posuere nunc. Donec diam nisl, rhoncus vel faucibus sed, porttitor sit amet ipsum. Donec at venenatis augue. Phasellus consequat lectus non augue vestibulum, at varius diam sagittis. Morbi nec purus augue. Etiam rutrum ullamcorper arcu vitae sollicitudin. Aliquam bibendum suscipit risus, at lacinia tortor efficitur ac.</p>
-        <p>Praesent vitae mi nec mauris vehicula ultricies nec ut felis. Nam vel nisi id nunc efficitur fermentum. Vestibulum mollis enim nec ultrices mattis. Curabitur placerat sed nisl lobortis iaculis. Fusce porttitor massa augue, sit amet faucibus enim finibus nec. Maecenas hendrerit metus in justo commodo viverra.</p>
         <button type="button" class="btn btn--text show-more__btn js-show-more__toggle js-show-more__btn" aria-expanded="false" aria-controls="more-content" aria-label="Show more about Lorem ipsum dolor sit amet">
             Show more...
         </button>
@@ -15,7 +14,7 @@ const Code = () => <Fragment>
             <p>Praesent vitae mi nec mauris vehicula ultricies nec ut felis. Nam vel nisi id nunc efficitur fermentum. Vestibulum mollis enim nec ultrices mattis. Curabitur placerat sed nisl lobortis iaculis. Fusce porttitor massa augue, sit amet faucibus enim finibus nec. Maecenas hendrerit metus in justo commodo viverra.</p>
         </div>
         <button type="button" class="btn btn--text show-more__btn--hide js-show-more__toggle js-show-more__btn-hide" aria-expanded="false" aria-controls="more-content" aria-label="Show less about Lorem ipsum dolor sit amet">
-            Show less ^
+            ...Show less
         </button>
     </div>
 </Fragment>;

--- a/src/templates/pages/example/show-more/index.js
+++ b/src/templates/pages/example/show-more/index.js
@@ -1,0 +1,14 @@
+import { h } from 'preact';
+import ExampleLayout from '@layouts/example';
+import Code from './code';
+
+export const title = 'Expandable section example';
+
+const ShowMore = () => <ExampleLayout>
+    <main class="wrap soft-top">
+        <h1 class="visuallyhidden">Show more example</h1>
+        <Code />
+    </main>
+</ExampleLayout>;
+
+export default ShowMore;

--- a/src/templates/pages/index.js
+++ b/src/templates/pages/index.js
@@ -13,6 +13,7 @@ import { status as modalConfirmationStatus } from "./patterns/modal-confirmation
 import { status as tabsStatus } from "./patterns/tabs";
 import { status as formValidationStatus } from "./patterns/form-validation";
 import { status as headingSubheadingStatus } from "./patterns/heading-subheading";
+import { status as showMoreStatus } from "./patterns/show-more";
 
 export const title = "Home";
 
@@ -33,6 +34,7 @@ const PATTERNS = [
 	{ title: "Modal confirmation", url: "/patterns/modal-confirmation", status: modalConfirmationStatus },
 	// { title: 'Modal gallery', url: '/patterns/modal-gallery' },
 	{ title: "Modal search", url: "/patterns/modal-search", status: modalSearchStatus },
+	{ title: "Show more", url: "/patterns/show-more", status: showMoreStatus },
 	{ title: "Tabs", url: "/patterns/tabs", status: tabsStatus },
 ];
 

--- a/src/templates/pages/patterns/show-more/index.js
+++ b/src/templates/pages/patterns/show-more/index.js
@@ -12,10 +12,11 @@ export const status = STATUS.DEVELOPMENT;
 
 const ExpandableSection = () => <PatternLayout>
     <PatternTitle status={status}>Show more</PatternTitle>
-    <p class="push-bottom--double">Show and hide a section of content</p>
+    <p class="push-bottom--double">An example pattern for progressive disclosure of content</p>
     
     <h2 class="push-bottom--half plus-2 medium">Guidance</h2>
-    <p class="push-bottom--double"></p>
+    <p class="push-bottom">Sometimes there may be a requirement to present users with key pieces of information only, to focus their attention.  Additional, more detailed information can be presented to them if they choose to display it.  This is known as <a href="https://www.nngroup.com/articles/progressive-disclosure/" rel="nofollow noopener">progessive disclosure</a>.</p>
+    <p class="push-bottom--double">The pattern below shows how this can be achieved using the StormID toggle component.</p>
     
     <h2 class="push-bottom--half plus-2 medium">Example</h2>
     <iframe style="--height: 375px" class="example" title="Example expandable section" src={'/example/show-more'}></iframe>
@@ -27,7 +28,7 @@ const ExpandableSection = () => <PatternLayout>
     
     <h2 class="push-bottom--half plus-2 medium">Code</h2>
     <pre class="pre"><code class="code">{`${render(<Code />, null, { pretty: true })}`}</code></pre>
-    <pre class="pre"><code class="code">{`mport toggle from '@stormid/toggle';
+    <pre class="pre"><code class="code">{`import toggle from '@stormid/toggle';
 const SELECTORS = {
     NODE: '.js-show-more',
     BLOCK: '.js-show-more__block',
@@ -47,13 +48,7 @@ export const init = () => {
             focus: false, 
             local: true,
             callback: (tog) => {
-                if (tog.isOpen) {
-                    currentBlock.setAttribute('tabindex', '-1');
-                    currentBlock.focus();
-                } else {
-                    currentBlock.removeAttribute('tabindex', '-1');
-                    currentShowMore.focus();
-                }
+                if (!tog.isOpen) currentShowMore.focus();
             }
         });
     })
@@ -66,22 +61,35 @@ init();`}</code></pre>
 
     <h3 class="push-bottom--half plus-1 medium">For validation in developer tools / web inspector</h3>
     <ul class="list list--tick push-bottom--double">
-        <li class="list-item"></li>
+        <li class="list-item">An HTML <pre class="pre--inline">&lt;button&gt;</pre> element is used to show the section</li>
+        <li class="list-item">An HTML <pre class="pre--inline">&lt;button&gt;</pre> element is used to hide the section</li>
+        <li class="list-item">An <pre class="pre--inline">aria-expanded</pre> attribute should be present on both <pre class="pre--inline">&lt;button&gt;</pre> elements.  The value of this should be 'true' when the section is expanded, and false when the section is collapsed.</li>
+        <li class="list-item">Both buttons <pre class="pre--inline">&lt;button&gt;</pre> should have an <pre class="pre--inline">aria-controls</pre> attribute.  The value of this should match the ID of the section being shown/hidden.</li>
     </ul>
 
     <h3 class="push-bottom--half plus-1 medium">For visual validation</h3>
     <ul class="list list--tick push-bottom--double">
-        <li class="list-item"></li>
+        <li class="list-item">Section show and hide buttons should have a clearly visible focus style which meets accessibility contrast requirements</li>
+        <li class="list-item">Section show/hide buttons should be no less than 44px x 44px in size (unless any of the allowed <a href="https://www.w3.org/TR/WCAG22/#target-size-enhanced">WCAG exceptions apply</a>)</li>
+        <li class="list-item">Show/hide buttons should be appropriately labelled to describe their functionality. If the design requires no visible text, a label should be added as an <pre class="pre--inline">aria-label</pre> attribute on the <pre class="pre--inline">&lt;button&gt;</pre> element</li>
+        <li class="list-item">The collapsed content should be hidden visually, hidden from keyboard access, and not read by screen readers</li>
+        <li class="list-item">The expanded content should be visible, available for keyboard access, and read by screen readers</li>
     </ul>
 
     <h3 class="push-bottom--half plus-1 medium">For functional validation</h3>
     <ul class="list list--tick push-bottom--double">
-        <li class="list-item"></li>
+        <li class="list-item">Show/hide buttons should be available to be tabbed to and activated via keyboard</li>
+        <li class="list-item">When expanded, keyboard focus should continue through the expanded content to any focusable elements within</li>
+        <li class="list-item">If content is hidden again after being expanded, focus should return to the 'show' button</li>
     </ul>
 
     <h2 class="push-bottom--half plus-2 medium">References</h2>
     <ul class="list push-bottom--double">
-        <li class="list-item"></li>
+        <li class="list-item"><a href="https://inclusive-components.design/collapsible-sections/" rel="noopener nofollow">https://inclusive-components.design/collapsible-sections/</a></li>
+        <li class="list-item"><a href="https://webaim.org/standards/wcag/checklist" rel="noopener nofollow">https://webaim.org/standards/wcag/checklist</a></li>
+        <li class="list-item"><a href="https://www.nngroup.com/articles/progressive-disclosure/" rel="noopener nofollow">https://www.nngroup.com/articles/progressive-disclosure/</a></li>
+        <li class="list-item"><a href="https://www.nngroup.com/articles/progressive-disclosure/" rel="noopener nofollow">https://www.nngroup.com/articles/progressive-disclosure/</a></li>
+        <li class="list-item"><a href="https://www.accede-web.com/en/guidelines/rich-interface-components/show-more-buttons/" rel="noopener nofollow">https://www.accede-web.com/en/guidelines/rich-interface-components/show-more-buttons//</a></li>
     </ul>
 </PatternLayout>;
 

--- a/src/templates/pages/patterns/show-more/index.js
+++ b/src/templates/pages/patterns/show-more/index.js
@@ -1,0 +1,88 @@
+import { h } from 'preact';
+import PatternLayout from '@layouts/pattern';
+import Code from '../../example/show-more/code';
+import { render } from 'preact-render-to-string';
+import PatternTitle from '@components/pattern-title';
+import DependencyTable from '@components/dependency-table';
+import { STATUS } from '@constants';
+
+export const title = 'Show more';
+
+export const status = STATUS.DEVELOPMENT;
+
+const ExpandableSection = () => <PatternLayout>
+    <PatternTitle status={status}>Show more</PatternTitle>
+    <p class="push-bottom--double">Show and hide a section of content</p>
+    
+    <h2 class="push-bottom--half plus-2 medium">Guidance</h2>
+    <p class="push-bottom--double"></p>
+    
+    <h2 class="push-bottom--half plus-2 medium">Example</h2>
+    <iframe style="--height: 375px" class="example" title="Example expandable section" src={'/example/show-more'}></iframe>
+    <p class="push-bottom align-right"><a href="/example/show-more" rel="noopener" target="_blank">Open in a new tab</a></p>
+
+    <h2 class="push-bottom--half plus-2 medium">Dependencies and installation</h2>
+    <DependencyTable dependencies={[{ package: '@stormid/toggle', installation: 'npm i -S @stormid/toggle' }]} />
+
+    
+    <h2 class="push-bottom--half plus-2 medium">Code</h2>
+    <pre class="pre"><code class="code">{`${render(<Code />, null, { pretty: true })}`}</code></pre>
+    <pre class="pre"><code class="code">{`mport toggle from '@stormid/toggle';
+const SELECTORS = {
+    NODE: '.js-show-more',
+    BLOCK: '.js-show-more__block',
+    MORE_BTN: '.js-show-more__btn',
+}
+
+export const init = () => {
+
+    const nodes = Array.from(document.querySelectorAll(SELECTORS.NODE));
+
+    nodes.forEach((node) => {
+        const currentBlock = node.querySelector(SELECTORS.BLOCK);
+        const currentShowMore = node.querySelector(SELECTORS.MORE_BTN);
+        if(!currentBlock || !currentShowMore) return;
+
+        const showMoreToggle = toggle(currentBlock, { 
+            focus: false, 
+            local: true,
+            callback: (tog) => {
+                if (tog.isOpen) {
+                    currentBlock.setAttribute('tabindex', '-1');
+                    currentBlock.focus();
+                } else {
+                    currentBlock.removeAttribute('tabindex', '-1');
+                    currentShowMore.focus();
+                }
+            }
+        });
+    })
+
+};
+
+init();`}</code></pre>
+    <h2 class="push-bottom plus-2 medium">Acceptance criteria</h2>
+    <p class="push-bottom--double">The following is a list of example acceptance criteria to test against when using this pattern.  These critera should test that the specific markup requirements are met, and that the expanding section behaves visually and functionally as expected.</p>
+
+    <h3 class="push-bottom--half plus-1 medium">For validation in developer tools / web inspector</h3>
+    <ul class="list list--tick push-bottom--double">
+        <li class="list-item"></li>
+    </ul>
+
+    <h3 class="push-bottom--half plus-1 medium">For visual validation</h3>
+    <ul class="list list--tick push-bottom--double">
+        <li class="list-item"></li>
+    </ul>
+
+    <h3 class="push-bottom--half plus-1 medium">For functional validation</h3>
+    <ul class="list list--tick push-bottom--double">
+        <li class="list-item"></li>
+    </ul>
+
+    <h2 class="push-bottom--half plus-2 medium">References</h2>
+    <ul class="list push-bottom--double">
+        <li class="list-item"></li>
+    </ul>
+</PatternLayout>;
+
+export default ExpandableSection;

--- a/src/templates/pages/patterns/show-more/index.js
+++ b/src/templates/pages/patterns/show-more/index.js
@@ -35,9 +35,20 @@ const SELECTORS = {
     MORE_BTN: '.js-show-more__btn',
 }
 
+export const showMoreFocus = (isOpen, currentBlock, currentShowMore) => {
+    if (isOpen) {
+        currentBlock.setAttribute('tabindex', '-1');
+        currentBlock.focus();
+    } else {
+        currentBlock.removeAttribute('tabindex', '-1');
+        currentShowMore.focus();
+    }
+}
+
 export const init = () => {
 
     const nodes = Array.from(document.querySelectorAll(SELECTORS.NODE));
+    const initialised = [];
 
     nodes.forEach((node) => {
         const currentBlock = node.querySelector(SELECTORS.BLOCK);
@@ -47,12 +58,12 @@ export const init = () => {
         const showMoreToggle = toggle(currentBlock, { 
             focus: false, 
             local: true,
-            callback: (tog) => {
-                if (!tog.isOpen) currentShowMore.focus();
-            }
+            callback: (tog) => showMoreFocus(tog.isOpen, currentBlock, currentShowMore)
         });
+        initialised.push(showMoreToggle);
     })
 
+    return initialised;
 };
 
 init();`}</code></pre>


### PR DESCRIPTION
Addresses #22 

Made use of the toggle component to implement this, going with the assumption that this pattern was meant to be for a simple content display, rather than any sort of AJAX content load.

Because of the disappearance of the 'Show more' button after the toggle, I placed a tabindex on the content div and put focus on it.   This isn't ideal, as I know a tabindex on a div isn't generally advised, but the [w3c has this as a passable test case ](https://www.w3.org/WAI/standards-guidelines/act/rules/0ssw9k/)for scrollable content, so I assume this is also a valid use.

Without it, the focus returns to the document and so the sequential tabbing is lost.  I tried this out in NVDA.

Let me know what you think!
Cheers,
S