### PR TITLE
Feature/69 tables

### DIFF
--- a/__tests__/patterns/table-overflow/index.js
+++ b/__tests__/patterns/table-overflow/index.js
@@ -1,0 +1,88 @@
+import { h } from 'preact';
+import TableOverflow from '../../../src/templates/pages/example/tables/overflow';
+import { render } from 'preact-render-to-string';
+
+describe('Table with overflow > mark up', () => {
+
+    beforeAll(() => {
+        document.body.innerHTML = render(<TableOverflow />);
+    });
+
+    it('Table should have a parent container', () => {
+        const tables = Array.from(document.querySelectorAll('table'));
+        for (const table of tables) {
+            const parentEl = table.parentNode;
+            expect(parentEl.nodeName === "DIV").toBeTruthy();
+            expect(parentEl.classList.contains('table__container--overflow')).toBeTruthy();
+        }
+    });
+
+    it('The parent container should have a tabindex of 0', () => {
+        const tables = Array.from(document.querySelectorAll('table'));
+        for (const table of tables) {
+            const parentEl = table.parentNode;
+            expect(parentEl.getAttribute("tabindex") === "0").toBeTruthy();
+        }  
+    });
+
+    it('The parent container should have an aria-labelleddby attribute', () => {
+        const tables = Array.from(document.querySelectorAll('table'));
+        for (const table of tables) {
+            const parentEl = table.parentNode;
+            expect(parentEl.hasAttribute("aria-labelledby")).toBeTruthy();
+        }    
+    });
+
+    it('Tables should have a table caption', () => {
+        const tables = Array.from(document.querySelectorAll('table'));
+        for (const table of tables) {
+            expect(table.querySelector("caption")).not.toBeNull();
+        }    
+    });
+
+    it('The aria-labelleddby attribute should match the ID of the table caption', () => {
+        const tables = Array.from(document.querySelectorAll('table'));
+        for (const table of tables) {
+            const parentEl = table.parentNode;
+            const ariaLabelID = parentEl.getAttribute("aria-labelledby");
+            expect(table.querySelector("caption#"+ ariaLabelID)).not.toBeNull();
+        }    
+    });
+
+    it('Tables should have a thead', () => {
+        const tables = Array.from(document.querySelectorAll('table'));
+        for (const table of tables) {
+            expect(table.querySelector("thead")).not.toBeNull();
+        }    
+    });
+
+    it('Tables should have a tbody', () => {
+        const tables = Array.from(document.querySelectorAll('table'));
+        for (const table of tables) {
+            expect(table.querySelector("tbody")).not.toBeNull();
+        }    
+    });
+
+    it('Table headers should have a scope', () => {
+        const headers = Array.from(document.querySelectorAll('th'));
+        for (const header of headers) {
+            expect(header.hasAttribute("scope")).toBeTruthy();
+        }    
+    });
+
+});
+
+describe('Table with overflow > keyboard', () => {
+    beforeAll(() => {
+        document.body.innerHTML = render(<TableOverflow />);
+    });
+
+    it('Should be possible to focus on the table container', () => {
+        const tables = Array.from(document.querySelectorAll('table'));
+        for (const table of tables) {
+            const parentEl = table.parentNode;
+            parentEl.focus();
+            expect(document.activeElement).toBe(parentEl);
+        }
+    });
+});

--- a/__tests__/patterns/table-responsive/index.js
+++ b/__tests__/patterns/table-responsive/index.js
@@ -1,0 +1,55 @@
+import { h } from 'preact';
+import TableResponsive from '../../../src/templates/pages/example/tables/responsive';
+import { render } from 'preact-render-to-string';
+
+describe('Table with responsive cards > mark up', () => {
+
+    beforeAll(() => {
+        document.body.innerHTML = render(<TableResponsive />);
+    });
+
+    it('Tables should have a table caption', () => {
+        const tables = Array.from(document.querySelectorAll('table'));
+        for (const table of tables) {
+            expect(table.querySelector("caption")).not.toBeNull();
+        }    
+    });
+
+    it('Tables should have a thead', () => {
+        const tables = Array.from(document.querySelectorAll('table'));
+        for (const table of tables) {
+            expect(table.querySelector("thead")).not.toBeNull();
+        }    
+    });
+
+    it('Tables should have a tbody', () => {
+        const tables = Array.from(document.querySelectorAll('table'));
+        for (const table of tables) {
+            expect(table.querySelector("tbody")).not.toBeNull();
+        }    
+    });
+
+    it('Table headers should have a scope', () => {
+        const headers = Array.from(document.querySelectorAll('th'));
+        for (const header of headers) {
+            expect(header.hasAttribute("scope")).toBeTruthy();
+        }    
+    });
+
+    it('Table cells should have a data attribute for the header', () => {
+        const tables = Array.from(document.querySelectorAll('table'));
+        for (const table of tables) {
+            const headers = Array.from(table.querySelectorAll('th'));
+            const rows = Array.from(document.querySelectorAll('tr'));
+
+            for (const row of rows) {
+                const cells = Array.from(row.querySelectorAll('td'));
+                cells.forEach((cell, index) => {
+                    expect(cell.getAttribute("data-th")).toEqual(headers[index].textContent);
+                })
+            }  
+        }  
+    });
+
+});
+

--- a/__tests__/patterns/table-row-links/index.js
+++ b/__tests__/patterns/table-row-links/index.js
@@ -1,0 +1,48 @@
+import { h } from 'preact';
+import TableRowLinks from '../../../src/templates/pages/example/tables/row-links';
+import { render } from 'preact-render-to-string';
+
+describe('Table with row links > mark up', () => {
+
+    beforeAll(() => {
+        document.body.innerHTML = render(<TableRowLinks />);
+    });
+
+    it('Tables should have a table caption', () => {
+        const tables = Array.from(document.querySelectorAll('table'));
+        for (const table of tables) {
+            expect(table.querySelector("caption")).not.toBeNull();
+        }    
+    });
+
+    it('Tables should have a thead', () => {
+        const tables = Array.from(document.querySelectorAll('table'));
+        for (const table of tables) {
+            expect(table.querySelector("thead")).not.toBeNull();
+        }    
+    });
+
+    it('Tables should have a tbody', () => {
+        const tables = Array.from(document.querySelectorAll('table'));
+        for (const table of tables) {
+            expect(table.querySelector("tbody")).not.toBeNull();
+        }    
+    });
+
+    it('Table headers should have a scope', () => {
+        const headers = Array.from(document.querySelectorAll('th'));
+        for (const header of headers) {
+            expect(header.hasAttribute("scope")).toBeTruthy();
+        }    
+    });
+
+    it('Table rows should have a single link', () => {
+        const rows = Array.from(document.querySelectorAll('tbody tr'));
+
+        for (const row of rows) {
+            expect(Array.from(row.querySelectorAll("a")).length).toEqual(1);
+        }  
+    });
+
+});
+

--- a/src/css/base/_spacing.scss
+++ b/src/css/base/_spacing.scss
@@ -10,6 +10,10 @@
 .soft-top {
     padding-top: var(--baseline) !important;
 }
+.soft-sides {
+    padding-left: var(--baseline) !important;
+    padding-right: var(--baseline) !important;
+}
 .push-top {
     margin-top: var(--baseline) !important;
 }

--- a/src/css/base/_table.scss
+++ b/src/css/base/_table.scss
@@ -1,0 +1,98 @@
+.table__container--base {
+    padding-top: calc(var(--baseline)/2);
+
+    .table {
+        width:100%;
+        margin: 0 auto;
+    }
+    .tr {
+        position: relative;
+        background-color: white;
+            &:hover {
+                background-color: transparent;
+                transition: background-color 120ms ease;
+            }
+    }
+    .th {
+        font-weight: normal;
+        text-align: left;
+        font-size: var(--font-size-minus-1);
+        padding: calc(var(--gutter)/2) calc(var(--gutter)/2);
+        margin-bottom: calc(var(--baseline)/4);
+        border-bottom: 8px solid rgba(0,0,0, 0);
+    }
+    .td {
+        color: currentColor;
+        padding: calc(var(--gutter)/2) calc(var(--gutter)/2);
+        border-bottom: 8px solid rgba(0,0,0, 0);
+    }
+    .th--tight {
+        padding: calc(var(--gutter)/8) 0;
+        vertical-align: middle;
+    }
+    .td--tight {
+        padding: calc(var(--gutter)/8) 0;
+        border-top: 1px solid rgba(0,0,0, .1);
+        border-bottom: 0 none;
+            a {
+                text-decoration: underline;
+                    &:hover,
+                    &:focus {
+                        text-decoration: none;
+                    }
+            }
+    }
+    .td--status {
+        text-align: right;
+        padding-right: 50px;
+    }
+    .th--status {
+        text-align: right;
+        padding-right: 72px;
+    }
+    .td__link {
+        text-decoration: none;
+        &:focus,
+        &:focus-visible {
+            outline: 0 none;
+            box-shadow: none;
+        }
+        &:before {
+            content: '';
+            position: absolute;
+            top: 4px;
+            right: 0;
+            bottom: 4px;
+            left: 0;
+        }
+        &:after {
+            position: absolute;
+            right: calc(var(--gutter)/1.5);
+            top:52%;
+            display: inline-block;
+            content: '';
+            width: 10px;
+            height: 10px;
+            border-right: 1px solid currentColor;
+            border-top: 1px solid currentColor;
+            transform: translateY(-50%) rotate(45deg);
+        }
+       
+        &:focus:before {
+            outline: 2px solid var(--highlight)
+        }
+    }
+    
+    //Dirty safari hack since it doesn't support relative positioning on tr
+    //https://stackoverflow.com/questions/16348489/is-there-a-css-hack-to-affect-safari-only-not-chrome
+    @media not all and (min-resolution:.001dpcm)
+    { @supports (-webkit-appearance:none) {
+        .td__link {
+            text-decoration: underline;
+        }
+        .td__link:before,
+        .td__link:after  {
+            display: none;
+        }
+    }}
+}

--- a/src/css/components/_example.scss
+++ b/src/css/components/_example.scss
@@ -15,6 +15,10 @@
             margin-bottom: 24px;
         }
     }
+
+    &-body{
+        background-color: white;
+    }
 }
 
 html { 

--- a/src/css/components/_table.scss
+++ b/src/css/components/_table.scss
@@ -1,54 +1,68 @@
 .table__container {
     width: 100%;
-    margin-bottom:calc(var(--baseline));
-    overflow-y: hidden;/* HACK/FIX FOR SAFARI, CANNOT POSITION RELATIVE A TABLE ROW*/
+    margin-bottom: calc(var(--baseline));
+    overflow-y: hidden;
+    /* HACK/FIX FOR SAFARI, CANNOT POSITION RELATIVE A TABLE ROW*/
     overflow-x: auto;
 }
 
 .table__container--overflow {
     background:
 
-    linear-gradient(
-      white 10%,
-      rgba(255, 255, 255, 0)
-    ) left top,
+        linear-gradient(white 10%,
+            rgba(255, 255, 255, 0)) left top,
 
-    linear-gradient(
-    rgba(255, 255, 255, 0) 50%,
-      white,
-    ) left bottom,
+        linear-gradient(rgba(255, 255, 255, 0) 50%,
+            white,
+        ) left bottom,
 
-    linear-gradient(
-      90deg,
-      white 30%,
-      rgba(255, 255, 255, 0)
-    ) left top,
-    
-    linear-gradient(
-      90deg,
-      rgba(255, 255, 255, 0), 
-      white 70%
-    ) right center,
-    
-    linear-gradient(
-      270deg,
-      rgba(0, 0, 0, 0),
-      rgba(0, 0, 0, 0.2)
-    ) left center,
-    
-    linear-gradient(
-      90deg,
-      rgba(0, 0, 0, 0),
-      rgba(0, 0, 0, 0.2)
-    ) right center;
-  
+        linear-gradient(90deg,
+            white 30%,
+            rgba(255, 255, 255, 0)) left top,
+
+        linear-gradient(90deg,
+            rgba(255, 255, 255, 0),
+            white 70%) right center,
+
+        linear-gradient(270deg,
+            rgba(0, 0, 0, 0),
+            rgba(0, 0, 0, 0.2)) left center,
+
+        linear-gradient(90deg,
+            rgba(0, 0, 0, 0),
+            rgba(0, 0, 0, 0.2)) right center;
+
     background-repeat: no-repeat;
     background-size: 100% 40px, 100% 100px, 40px 100%, 40px 100%, 14px 100%, 14px 100%;
     background-attachment: local, local, local, local, scroll, scroll;
 }
 
+.table__container--overflow-sticky {
+    background:
+
+        linear-gradient(white 10%,
+            rgba(255, 255, 255, 0)) left top,
+
+        linear-gradient(rgba(255, 255, 255, 0) 50%,
+            white,
+        ) left bottom,
+
+        linear-gradient(90deg,
+            rgba(255, 255, 255, 0),
+            white 70%) right center,
+
+        linear-gradient(90deg,
+            rgba(0, 0, 0, 0),
+            rgba(0, 0, 0, 0.2)) right center;
+
+    background-repeat: no-repeat;
+    background-size: 100% 40px, 100% 100px, 40px 100%, 14px 100%;
+    background-attachment: local, local, local, scroll;
+}
+
+
 .table {
-    width:100%;
+    width: 100%;
     position: relative;
     padding-bottom: 2rem;
 }
@@ -60,19 +74,20 @@
 .table--has-caption {
     margin-bottom: calc(var(--baseline)*3.5);
 }
-    
+
 .table__caption {
     text-align: right;
     position: absolute;
-    bottom:calc(var(--baseline)*-2);
-    width:100%
+    bottom: calc(var(--baseline)*-2);
+    width: 100%
 }
 
 .table__container--flush {
     margin-bottom: 0;
-        .table {
-            padding-bottom: 0;
-        }
+
+    .table {
+        padding-bottom: 0;
+    }
 }
 
 .table__row {
@@ -83,29 +98,31 @@
 
 .table__row--link {
     position: relative;
-    transform: scale(1,1);/* HACK/FIX FOR SAFARI, CANNOT POSITION RELATIVE A TABLE ROW*/
+    transform: scale(1, 1);
+    /* HACK/FIX FOR SAFARI, CANNOT POSITION RELATIVE A TABLE ROW*/
 
-        &:hover {
-            background-color: var(--light-grey-1);
-            transition: background-color 60ms ease;
-        }
-        .table__td:nth-last-child(2) {
-            position: relative;
-            padding-right: 25px;
+    &:hover {
+        background-color: var(--light-grey-1);
+        transition: background-color 60ms ease;
+    }
 
-            &:after {
-                position: absolute;
-                right: calc(var(--gutter)/2);
-                top: 50%;
-                display: inline-block;
-                content: '';
-                width: 10px;
-                height: 10px;
-                border-right: 1px solid currentColor;
-                border-top: 1px solid currentColor;
-                transform: translateY(-50%) rotate(45deg);
-            }
+    .table__td:nth-last-child(2) {
+        position: relative;
+        padding-right: 25px;
+
+        &:after {
+            position: absolute;
+            right: calc(var(--gutter)/2);
+            top: 50%;
+            display: inline-block;
+            content: '';
+            width: 10px;
+            height: 10px;
+            border-right: 1px solid currentColor;
+            border-top: 1px solid currentColor;
+            transform: translateY(-50%) rotate(45deg);
         }
+    }
 }
 
 .table__th {
@@ -147,15 +164,29 @@
 .table__td--link,
 .table__link {
     position: fixed;
-    left:0;
-    top:0;
-    right:0;
-    bottom:0;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
     border-bottom: 0 none;
 }
 
+.table__container--overflow-sticky {
 
-@media(max-width: map-get($mq-breakpoints,  xs)){
+    .table__td:first-child,
+    .table__th:first-child {
+        position: sticky;
+        left: 0;
+        background: linear-gradient(90deg, #d1d1d1 1px, white 1px);
+        background-color: white;
+        background-position: 100% 0;
+        background-repeat: repeat-y;
+        background-size: 1px;
+    }
+}
+
+
+@media(max-width: map-get($mq-breakpoints, xs)) {
 
     .table__container:not(.table__container--overflow) {
         display: block;
@@ -167,55 +198,59 @@
         .table__td {
             display: block;
         }
+
         .table__th {
             border: 0 none;
         }
-    
+
         .table__row {
             position: relative;
-                &:last-child:after {
-                    content: '';
-                    display: block;
-                    margin-bottom: calc(var(--baseline)/2);
-                    border-bottom: 1px solid var(--light-grey-2);
-                    width:100%;
-                    position: absolute;
-                    bottom: calc(var(--baseline)*-.5);
-                }
+
+            &:last-child:after {
+                content: '';
+                display: block;
+                margin-bottom: calc(var(--baseline)/2);
+                border-bottom: 1px solid var(--light-grey-2);
+                width: 100%;
+                position: absolute;
+                bottom: calc(var(--baseline)*-.5);
+            }
         }
-        
+
         .table__th {
             display: none;
         }
-        
+
         .table__td {
             padding: 0;
             border-bottom: 0 none;
-    
+
             &.align-right {
                 text-align: right;
             }
-    
+
             &:first-child {
                 padding-top: calc(var(--baseline)/2);
             }
-    
+
             &:last-child {
                 margin-bottom: 0;
                 padding-bottom: calc(var(--baseline)/2);
                 border-bottom: 1px solid var(--light-grey-2);
             }
         }
+
         .table__row--link {
             .table__td:nth-last-child(2) {
                 padding-bottom: calc(var(--baseline)/2);
             }
         }
+
         .table__td--link:last-child {
             border-bottom: 0 none;
         }
-    
-        
+
+
         [data-th]:before {
             font-size: var(--font-size-minus-2);
             content: attr(data-th);
@@ -223,11 +258,11 @@
             display: block;
             color: var(--dark-grey-1);
         }
-    
+
         .table__caption {
             text-align: left;
         }
     }
 
-    
+
 }

--- a/src/css/components/_table.scss
+++ b/src/css/components/_table.scss
@@ -1,97 +1,233 @@
 .table__container {
-    padding-top: calc(var(--baseline)/2);
+    width: 100%;
+    margin-bottom:calc(var(--baseline));
+    overflow-y: hidden;/* HACK/FIX FOR SAFARI, CANNOT POSITION RELATIVE A TABLE ROW*/
+    overflow-x: auto;
 }
+
+.table__container--overflow {
+    background:
+
+    linear-gradient(
+      white 10%,
+      rgba(255, 255, 255, 0)
+    ) left top,
+
+    linear-gradient(
+    rgba(255, 255, 255, 0) 50%,
+      white,
+    ) left bottom,
+
+    linear-gradient(
+      90deg,
+      white 30%,
+      rgba(255, 255, 255, 0)
+    ) left top,
+    
+    linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0), 
+      white 70%
+    ) right center,
+    
+    linear-gradient(
+      270deg,
+      rgba(0, 0, 0, 0),
+      rgba(0, 0, 0, 0.2)
+    ) left center,
+    
+    linear-gradient(
+      90deg,
+      rgba(0, 0, 0, 0),
+      rgba(0, 0, 0, 0.2)
+    ) right center;
+  
+    background-repeat: no-repeat;
+    background-size: 100% 40px, 100% 100px, 40px 100%, 40px 100%, 14px 100%, 14px 100%;
+    background-attachment: local, local, local, local, scroll, scroll;
+}
+
 .table {
     width:100%;
-    margin: 0 auto;
-}
-.tr {
     position: relative;
-    background-color: white;
-        &:hover {
-            background-color: transparent;
-            transition: background-color 120ms ease;
+    padding-bottom: 2rem;
+}
+
+.table__container--overflow .table {
+    table-layout: fixed;
+}
+
+.table--has-caption {
+    margin-bottom: calc(var(--baseline)*3.5);
+}
+    
+.table__caption {
+    text-align: right;
+    position: absolute;
+    bottom:calc(var(--baseline)*-2);
+    width:100%
+}
+
+.table__container--flush {
+    margin-bottom: 0;
+        .table {
+            padding-bottom: 0;
         }
 }
-.th {
-    font-weight: normal;
-    text-align: left;
-    font-size: var(--font-size-minus-1);
-    padding: calc(var(--gutter)/2) calc(var(--gutter)/2);
-    margin-bottom: calc(var(--baseline)/4);
-    border-bottom: 8px solid rgba(0,0,0, 0);
-}
-.td {
-    color: currentColor;
-    padding: calc(var(--gutter)/2) calc(var(--gutter)/2);
-    border-bottom: 8px solid rgba(0,0,0, 0);
-}
-.th--tight {
-    padding: calc(var(--gutter)/8) 0;
-    vertical-align: middle;
-}
-.td--tight {
-    padding: calc(var(--gutter)/8) 0;
-    border-top: 1px solid rgba(0,0,0, .1);
-    border-bottom: 0 none;
-        a {
-            text-decoration: underline;
-                &:hover,
-                &:focus {
-                    text-decoration: none;
-                }
-        }
-}
-.td--status {
-    text-align: right;
-    padding-right: 50px;
-}
-.th--status {
-    text-align: right;
-    padding-right: 72px;
-}
-.td__link {
-    text-decoration: none;
-    &:focus,
-    &:focus-visible {
-        outline: 0 none;
-        box-shadow: none;
-    }
-    &:before {
-        content: '';
-        position: absolute;
-        top: 4px;
-        right: 0;
-        bottom: 4px;
-        left: 0;
-    }
-    &:after {
-        position: absolute;
-        right: calc(var(--gutter)/1.5);
-        top:52%;
-        display: inline-block;
-        content: '';
-        width: 10px;
-        height: 10px;
-        border-right: 1px solid currentColor;
-        border-top: 1px solid currentColor;
-        transform: translateY(-50%) rotate(45deg);
-    }
-   
-    &:focus:before {
-        outline: 2px solid var(--highlight)
+
+.table__row {
+    &:last-child .table__td {
+        border-bottom: 0 none;
     }
 }
 
-//Dirty safari hack since it doesn't support relative positioning on tr
-//https://stackoverflow.com/questions/16348489/is-there-a-css-hack-to-affect-safari-only-not-chrome
-@media not all and (min-resolution:.001dpcm)
-{ @supports (-webkit-appearance:none) {
-    .td__link {
-        text-decoration: underline;
+.table__row--link {
+    position: relative;
+    transform: scale(1,1);/* HACK/FIX FOR SAFARI, CANNOT POSITION RELATIVE A TABLE ROW*/
+
+        &:hover {
+            background-color: var(--light-grey-1);
+            transition: background-color 60ms ease;
+        }
+        .table__td:nth-last-child(2) {
+            position: relative;
+            padding-right: 25px;
+
+            &:after {
+                position: absolute;
+                right: calc(var(--gutter)/2);
+                top: 50%;
+                display: inline-block;
+                content: '';
+                width: 10px;
+                height: 10px;
+                border-right: 1px solid currentColor;
+                border-top: 1px solid currentColor;
+                transform: translateY(-50%) rotate(45deg);
+            }
+        }
+}
+
+.table__th {
+    font-size: var(--font-size-minus-1);
+    display: table-cell;
+    border-bottom: 1px solid var(--light-grey-2);
+    padding: calc(var(--baseline)/6) var(--gutter) calc(var(--baseline)/2) var(--gutter);
+    text-align: left;
+    font-weight: var(--regular-weight);
+    color: var(--dark-grey-1);
+
+    &:first-child {
+        padding-left: 0;
     }
-    .td__link:before,
-    .td__link:after  {
-        display: none;
+
+    &.align-right {
+        text-align: right;
     }
-}}
+}
+
+.table__container--overflow .table__th {
+    width: 150px;
+}
+
+.table__th--hidden {
+    @include visuallyhidden;
+}
+
+.table__td {
+    padding: var(--baseline) var(--gutter) var(--baseline) var(--gutter);
+    border-bottom: 1px solid var(--light-grey-2);
+    vertical-align: top;
+
+    &:first-child {
+        padding-left: 0;
+    }
+}
+
+.table__td--link,
+.table__link {
+    position: fixed;
+    left:0;
+    top:0;
+    right:0;
+    bottom:0;
+    border-bottom: 0 none;
+}
+
+
+@media(max-width: map-get($mq-breakpoints,  xs)){
+
+    .table__container:not(.table__container--overflow) {
+        display: block;
+
+        .table__head,
+        .table__header,
+        .table__bd,
+        .table__row,
+        .table__td {
+            display: block;
+        }
+        .table__th {
+            border: 0 none;
+        }
+    
+        .table__row {
+            position: relative;
+                &:last-child:after {
+                    content: '';
+                    display: block;
+                    margin-bottom: calc(var(--baseline)/2);
+                    border-bottom: 1px solid var(--light-grey-2);
+                    width:100%;
+                    position: absolute;
+                    bottom: calc(var(--baseline)*-.5);
+                }
+        }
+        
+        .table__th {
+            display: none;
+        }
+        
+        .table__td {
+            padding: 0;
+            border-bottom: 0 none;
+    
+            &.align-right {
+                text-align: right;
+            }
+    
+            &:first-child {
+                padding-top: calc(var(--baseline)/2);
+            }
+    
+            &:last-child {
+                margin-bottom: 0;
+                padding-bottom: calc(var(--baseline)/2);
+                border-bottom: 1px solid var(--light-grey-2);
+            }
+        }
+        .table__row--link {
+            .table__td:nth-last-child(2) {
+                padding-bottom: calc(var(--baseline)/2);
+            }
+        }
+        .table__td--link:last-child {
+            border-bottom: 0 none;
+        }
+    
+        
+        [data-th]:before {
+            font-size: var(--font-size-minus-2);
+            content: attr(data-th);
+            padding-top: calc(var(--baseline)/2);
+            display: block;
+            color: var(--dark-grey-1);
+        }
+    
+        .table__caption {
+            text-align: left;
+        }
+    }
+
+    
+}

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -7,6 +7,7 @@
 @import 'base/typography';
 @import 'base/spacing';
 @import 'base/visibility';
+@import 'base/table';
 
 @import 'components/skip';
 @import 'components/header';

--- a/src/templates/components/body/index.js
+++ b/src/templates/components/body/index.js
@@ -1,5 +1,5 @@
 import { h } from 'preact';
 
-const Body = ({children}) => <body>{children}</body>;
+const Body = ({children, bodyClass}) => <body class={bodyClass}>{children}</body>;
 
 export default Body;

--- a/src/templates/components/html/index.js
+++ b/src/templates/components/html/index.js
@@ -8,10 +8,11 @@ const Html = ({
     meta,
     css,
     basePath,
-    children
+    children,
+    bodyClass
 }) => <html lang={lang}>
     <Head title={title} meta={meta} css={css} />
-    <Body>
+    <Body bodyClass={bodyClass}>
         {children}
         <script nomodule src={`${basePath}/polyfills.js`} />
         <script src={`${basePath}/index.js`} />

--- a/src/templates/components/table/index.js
+++ b/src/templates/components/table/index.js
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import Th from './th';
 
-const Table =  ({ className, caption, head, rows = [], emptyMessage = 'No data available' }) => <div class={`table__container${className ? ` ${className}` : ''}`}>
+const Table =  ({ className, caption, head, rows = [], emptyMessage = 'No data available', tabindex }) => <div class={`table__container${className ? ` ${className}` : ''}`} tabindex={tabindex}>
     <table class={`table${caption ? ` table--has-caption` : ``}`}>
         {caption && <caption class="table__caption">{caption}</caption>}
         <thead class="table__head">

--- a/src/templates/components/table/index.js
+++ b/src/templates/components/table/index.js
@@ -1,9 +1,9 @@
 import { h } from 'preact';
 import Th from './th';
 
-const Table =  ({ className, caption, head, rows = [], emptyMessage = 'No data available', tabindex }) => <div class={`table__container${className ? ` ${className}` : ''}`} tabindex={tabindex}>
+const Table =  ({ className, caption, head, rows = [], emptyMessage = 'No data available', tabindex, id }) => <div class={`table__container${className ? ` ${className}` : ''}`} tabindex={tabindex} aria-labelledby={id}>
     <table class={`table${caption ? ` table--has-caption` : ``}`}>
-        {caption && <caption class="table__caption">{caption}</caption>}
+        {caption && <caption id={id} class="table__caption">{caption}</caption>}
         <thead class="table__head">
             <tr class="table__row">
                 {

--- a/src/templates/components/table/index.js
+++ b/src/templates/components/table/index.js
@@ -1,0 +1,40 @@
+import { h } from 'preact';
+import Th from './th';
+
+const Table =  ({ className, caption, head, rows = [], emptyMessage = 'No data available' }) => <div class={`table__container${className ? ` ${className}` : ''}`}>
+    <table class={`table${caption ? ` table--has-caption` : ``}`}>
+        {caption && <caption class="table__caption">{caption}</caption>}
+        <thead class="table__head">
+            <tr class="table__row">
+                {
+                    head.map((cell, idx) => <Th
+                        scope={cell.scope}
+                        isNumeric={cell.isNumeric}
+                    >
+                        {cell.value}
+                    </Th>
+                    )
+                }
+                {rows.reduce((acc, row) => acc || row.link, false) && <Th className={'table__th--hidden'}>Link</Th>}
+            </tr>
+        </thead>
+        <tbody class="table__bd">
+            {
+                rows.length > 0
+                    ? rows.map(row => <tr class={`table__row${row.link ? ` table__row--link` : ''}`}>
+                        {row.cells.map((cell, idx) => <td data-th={head[idx].value} class={`table__td${cell.className ? ` ${cell.className}` : ''}${cell.isNumeric ? ' table__td--right' : ''}${cell.status ? ` table__td--status` : ``}`}>
+                            {cell.value}
+                        </td>)}
+                        {row.link && <td class="table__td table__td--link"><a class="table__link" href={row.link.href}><span class="visually-hidden">{row.link.label || row.link.href}</span></a></td>}
+                    </tr>)
+                    : <tr class={`table__row`}>
+                        <td colspan={head.length} class="table__td align-center">{emptyMessage}</td>
+                    </tr>
+            }
+        </tbody>
+    </table>
+</div>;
+
+export default Table;
+
+export const NoValue = () => <span aria-label="No value">--</span>;

--- a/src/templates/components/table/th/index.js
+++ b/src/templates/components/table/th/index.js
@@ -1,0 +1,10 @@
+import { h } from 'preact';
+
+const Th = ({
+    scope = 'col',
+    className,
+    isNumeric,
+    children
+}) => <th class={`table__th${isNumeric ? ' table__th--right' : ''}${className ? ` ${className}` : ''}`} scope={scope}>{children}</th>;
+
+export default Th;

--- a/src/templates/layouts/example.js
+++ b/src/templates/layouts/example.js
@@ -1,7 +1,7 @@
-import { h } from 'preact';
+import { h, Fragment } from 'preact';
 
-const Example = ({ children }) => <body style="background-color: white">
+const Example = ({ children }) => <Fragment>
     { children }
-</body>;
+</Fragment>;
 
 export default Example;

--- a/src/templates/pages/example/cookie-banner/form.js
+++ b/src/templates/pages/example/cookie-banner/form.js
@@ -2,6 +2,7 @@ import { h } from 'preact';
 import ExampleLayout from '@layouts/example';
 
 export const title = 'Cookie banner example';
+export const bodyClass = 'example-body';
 
 const CookieBanner = () => <ExampleLayout>
     <main class="wrap soft-top" id="js-cookie-banner-example">

--- a/src/templates/pages/example/cookie-banner/index.js
+++ b/src/templates/pages/example/cookie-banner/index.js
@@ -3,6 +3,7 @@ import ExampleLayout from '@layouts/example';
 import Code from './code';
 
 export const title = 'Cookie banner example';
+export const bodyClass = 'example-body';
 
 const CookieBanner = () => <ExampleLayout>
     <main class="wrap soft-top" id="js-cookie-banner-example">

--- a/src/templates/pages/example/exclusive-toggles/index.js
+++ b/src/templates/pages/example/exclusive-toggles/index.js
@@ -3,6 +3,7 @@ import ExampleLayout from '@layouts/example';
 import Code from './code';
 
 export const title = 'Exclusive toggles example';
+export const bodyClass = 'example-body';
 
 const ExclusiveToggles = () => <ExampleLayout>
     <Code />

--- a/src/templates/pages/example/expandable-navigation/index.js
+++ b/src/templates/pages/example/expandable-navigation/index.js
@@ -3,6 +3,7 @@ import ExampleLayout from '@layouts/example';
 import Code from './code';
 
 export const title = 'Expandable navigation example';
+export const bodyClass = 'example-body';
 
 const OffCanvasNav = () => <ExampleLayout>
     <header class="expandable-nav__container">

--- a/src/templates/pages/example/expandable-search/index.js
+++ b/src/templates/pages/example/expandable-search/index.js
@@ -3,6 +3,7 @@ import ExampleLayout from '@layouts/example';
 import Code from './code';
 
 export const title = 'Expandable search example';
+export const bodyClass = 'example-body';
 
 const ExpandableSearch = () => <ExampleLayout>
     <header class="expandable-search__header">

--- a/src/templates/pages/example/expandable-section/index.js
+++ b/src/templates/pages/example/expandable-section/index.js
@@ -3,6 +3,7 @@ import ExampleLayout from '@layouts/example';
 import Code from './code';
 
 export const title = 'Expandable section example';
+export const bodyClass = 'example-body';
 
 const ModalSearch = () => <ExampleLayout>
     <main class="wrap soft-top">

--- a/src/templates/pages/example/form-headings/form-headings-multiple/index.js
+++ b/src/templates/pages/example/form-headings/form-headings-multiple/index.js
@@ -3,6 +3,7 @@ import ExampleLayout from '@layouts/example';
 import Code from './code';
 
 export const title = 'Form page headings - multiple question example';
+export const bodyClass = 'example-body';
 
 const FormPatternMultiple = () => <ExampleLayout>
     <main class="soft-top">

--- a/src/templates/pages/example/form-headings/form-headings-single-multi/index.js
+++ b/src/templates/pages/example/form-headings/form-headings-single-multi/index.js
@@ -3,6 +3,7 @@ import ExampleLayout from '@layouts/example';
 import Code from './code';
 
 export const title = 'Form page heading - single question multi choice';
+export const bodyClass = 'example-body';
 
 const FormPatternSingleMulti = () => <ExampleLayout>
     <main class="soft-top">

--- a/src/templates/pages/example/form-headings/form-headings-single/index.js
+++ b/src/templates/pages/example/form-headings/form-headings-single/index.js
@@ -3,6 +3,7 @@ import ExampleLayout from '@layouts/example';
 import Code from './code';
 
 export const title = 'Form page headings - single question example';
+export const bodyClass = 'example-body';
 
 const FormPatternSingle = () => <ExampleLayout>
     <main class="soft-top">

--- a/src/templates/pages/example/form-validation/index.js
+++ b/src/templates/pages/example/form-validation/index.js
@@ -3,6 +3,7 @@ import ExampleLayout from '@layouts/example';
 import Code from './code';
 
 export const title = 'Form validation example';
+export const bodyClass = 'example-body';
 
 const FormValidation = () => <ExampleLayout>
     <main class="soft-top">

--- a/src/templates/pages/example/full-screen-navigation/index.js
+++ b/src/templates/pages/example/full-screen-navigation/index.js
@@ -3,6 +3,7 @@ import ExampleLayout from '@layouts/example';
 import Code from './code';
 
 export const title = 'Full screen navigation example';
+export const bodyClass = 'example-body';
 
 const ModalFullScreenNav = () => <ExampleLayout>
     <header class="full-screen-nav__header">

--- a/src/templates/pages/example/heading-subheading/card/index.js
+++ b/src/templates/pages/example/heading-subheading/card/index.js
@@ -3,6 +3,7 @@ import ExampleLayout from '@layouts/example';
 import Code from './code';
 
 export const title = 'Heading with subheading example card';
+export const bodyClass = 'example-body';
 
 const HeadingSubheadingCard = () => <ExampleLayout>
     <main class="wrap soft-top">

--- a/src/templates/pages/example/heading-subheading/hero/index.js
+++ b/src/templates/pages/example/heading-subheading/hero/index.js
@@ -3,6 +3,7 @@ import ExampleLayout from '@layouts/example';
 import Code from './code';
 
 export const title = 'Heading with subheading example hero';
+export const bodyClass = 'example-body';
 
 const HeadingSubheadingHero = () => <ExampleLayout>
     <main class="wrap soft-top">

--- a/src/templates/pages/example/modal-confirmation/index.js
+++ b/src/templates/pages/example/modal-confirmation/index.js
@@ -3,6 +3,7 @@ import ExampleLayout from '@layouts/example';
 import Code from './code';
 
 export const title = 'Modal confirmation  example';
+export const bodyClass = 'example-body';
 
 const ModalConfirmation = () => <ExampleLayout>
     <main>

--- a/src/templates/pages/example/modal-search/index.js
+++ b/src/templates/pages/example/modal-search/index.js
@@ -3,6 +3,7 @@ import ExampleLayout from '@layouts/example';
 import Code from './code';
 
 export const title = 'Modal search example';
+export const bodyClass = 'example-body';
 
 const ModalSearch = () => <ExampleLayout>
     <header class="modal-search__container">

--- a/src/templates/pages/example/tables/overflow-sticky/code.js
+++ b/src/templates/pages/example/tables/overflow-sticky/code.js
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import Table from '@components/table';
 
-export const Code = () => (<Table tabindex="0" caption="Example table" className={"table__container--overflow"}
+export const Code = () => (<Table tabindex="0" caption="Example table" className={"table__container--overflow table__container--overflow-sticky"}
     rows={[
         { cells: [ {"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970"} ] },
         { cells: [ {"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970"} ] },

--- a/src/templates/pages/example/tables/overflow-sticky/code.js
+++ b/src/templates/pages/example/tables/overflow-sticky/code.js
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import Table from '@components/table';
 
-export const Code = () => (<Table tabindex="0" caption="Example table" className={"table__container--overflow table__container--overflow-sticky"}
+export const Code = () => (<Table tabindex="0" id="scrolltableStickyCaption" caption="Example table" className={"table__container--overflow table__container--overflow-sticky"}
     rows={[
         { cells: [ {"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970"} ] },
         { cells: [ {"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970"} ] },

--- a/src/templates/pages/example/tables/overflow-sticky/index.js
+++ b/src/templates/pages/example/tables/overflow-sticky/index.js
@@ -3,6 +3,7 @@ import ExampleLayout from '@layouts/example';
 import Code from './code';
 
 export const title = 'Table example with scrollable overflow and sticky column';
+export const bodyClass = 'example-body';
 
 const TableOverflow = () => <ExampleLayout>
     <main class="soft-top soft-sides">

--- a/src/templates/pages/example/tables/overflow-sticky/index.js
+++ b/src/templates/pages/example/tables/overflow-sticky/index.js
@@ -1,0 +1,13 @@
+import { h } from 'preact';
+import ExampleLayout from '@layouts/example';
+import Code from './code';
+
+export const title = 'Table example with scrollable overflow and sticky column';
+
+const TableOverflow = () => <ExampleLayout>
+    <main class="soft-top soft-sides">
+        <Code />
+    </main>
+</ExampleLayout>;
+
+export default TableOverflow;

--- a/src/templates/pages/example/tables/overflow/code.js
+++ b/src/templates/pages/example/tables/overflow/code.js
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import Table from '@components/table';
 
-export const Code = () => (<Table tabindex="0" caption="Example table" className={"table__container--overflow"}
+export const Code = () => (<Table tabindex="0" id="scrolltableCaption" caption="Example table" className={"table__container--overflow"}
     rows={[
         { cells: [ {"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970"} ] },
         { cells: [ {"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970"} ] },

--- a/src/templates/pages/example/tables/overflow/code.js
+++ b/src/templates/pages/example/tables/overflow/code.js
@@ -1,0 +1,14 @@
+import { h } from 'preact';
+import Table from '@components/table';
+
+export const Code = () => (<Table className={"table__container--overflow"}
+    rows={[
+        { cells: [ {"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970"} ] },
+        { cells: [ {"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970"} ] },
+        { cells: [ {"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970"} ] },
+    ]}
+    head={[{"value": "Name"}, {"value": "Job title"}, {"value": "Date of birth"}]}
+/>)
+
+export default Code;
+

--- a/src/templates/pages/example/tables/overflow/index.js
+++ b/src/templates/pages/example/tables/overflow/index.js
@@ -1,0 +1,13 @@
+import { h } from 'preact';
+import ExampleLayout from '@layouts/example';
+import Code from './code';
+
+export const title = 'Table example with scrollable overflow';
+
+const TableOverflow = () => <ExampleLayout>
+    <main class="soft-top soft-sides">
+        <Code />
+    </main>
+</ExampleLayout>;
+
+export default TableOverflow;

--- a/src/templates/pages/example/tables/overflow/index.js
+++ b/src/templates/pages/example/tables/overflow/index.js
@@ -3,6 +3,7 @@ import ExampleLayout from '@layouts/example';
 import Code from './code';
 
 export const title = 'Table example with scrollable overflow';
+export const bodyClass = 'example-body';
 
 const TableOverflow = () => <ExampleLayout>
     <main class="soft-top soft-sides">

--- a/src/templates/pages/example/tables/responsive/code.js
+++ b/src/templates/pages/example/tables/responsive/code.js
@@ -1,0 +1,13 @@
+import { h } from 'preact';
+import Table from '@components/table';
+
+export const Code = () => (<Table
+    rows={[
+        { cells: [ {"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970"} ] },
+        { cells: [ {"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970"} ] },
+        { cells: [ {"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970"} ] },
+    ]}
+    head={[{"value": "Name"}, {"value": "Job title"}, {"value": "Date of birth"}]}
+/>)
+
+export default Code;

--- a/src/templates/pages/example/tables/responsive/code.js
+++ b/src/templates/pages/example/tables/responsive/code.js
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import Table from '@components/table';
 
-export const Code = () => (<Table
+export const Code = () => (<Table caption="Example table" 
     rows={[
         { cells: [ {"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970"} ] },
         { cells: [ {"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970"} ] },

--- a/src/templates/pages/example/tables/responsive/index.js
+++ b/src/templates/pages/example/tables/responsive/index.js
@@ -3,6 +3,7 @@ import ExampleLayout from '@layouts/example';
 import Code from './code';
 
 export const title = 'Table example - responsive';
+export const bodyClass = 'example-body';
 
 const TableResponsive = () => <ExampleLayout>
     <main class="soft-top soft-sides">

--- a/src/templates/pages/example/tables/responsive/index.js
+++ b/src/templates/pages/example/tables/responsive/index.js
@@ -1,0 +1,13 @@
+import { h } from 'preact';
+import ExampleLayout from '@layouts/example';
+import Code from './code';
+
+export const title = 'Table example - responsive';
+
+const TableResponsive = () => <ExampleLayout>
+    <main class="soft-top soft-sides">
+        <Code />
+    </main>
+</ExampleLayout>;
+
+export default TableResponsive;

--- a/src/templates/pages/example/tables/row-links/code.js
+++ b/src/templates/pages/example/tables/row-links/code.js
@@ -3,10 +3,10 @@ import Table from '@components/table'
 
 export const Code = () => <Table caption="Example table" 
 rows={[
-    { link: { href: '#', label: 'Joe Example' }, cells: [{"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970 (53y)"}] },
-    { link: { href: '#', label: 'Joe Example' }, cells: [{"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970 (53y)"}] },
-    { link: { href: '#', label: 'Joe Example' }, cells: [{"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970 (53y)"}] },
-    { link: { href: '#', label: 'Joe Example' }, cells: [{"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970 (53y)"}] },
+    { link: { href: '#', label: 'More details about Joe Example' }, cells: [{"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970"}] },
+    { link: { href: '#', label: 'More details about Joe Example' }, cells: [{"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970"}] },
+    { link: { href: '#', label: 'More details about Joe Example' }, cells: [{"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970"}] },
+    { link: { href: '#', label: 'More details about Joe Example' }, cells: [{"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970"}] },
 ]}
 head={[{"value": "Name"}, {"value": "Job title"}, {"value": "Date of birth"}]}
 />;

--- a/src/templates/pages/example/tables/row-links/code.js
+++ b/src/templates/pages/example/tables/row-links/code.js
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import Table from '@components/table'
 
-export const Code = () => <Table
+export const Code = () => <Table caption="Example table" 
 rows={[
     { link: { href: '#', label: 'Joe Example' }, cells: [{"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970 (53y)"}] },
     { link: { href: '#', label: 'Joe Example' }, cells: [{"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970 (53y)"}] },

--- a/src/templates/pages/example/tables/row-links/code.js
+++ b/src/templates/pages/example/tables/row-links/code.js
@@ -1,0 +1,14 @@
+import { h } from 'preact';
+import Table from '@components/table'
+
+export const Code = () => <Table
+rows={[
+    { link: { href: '#', label: 'Joe Example' }, cells: [{"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970 (53y)"}] },
+    { link: { href: '#', label: 'Joe Example' }, cells: [{"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970 (53y)"}] },
+    { link: { href: '#', label: 'Joe Example' }, cells: [{"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970 (53y)"}] },
+    { link: { href: '#', label: 'Joe Example' }, cells: [{"value": "Joe Example"},{"value": "Web developer"},{"value": "1 Jan 1970 (53y)"}] },
+]}
+head={[{"value": "Name"}, {"value": "Job title"}, {"value": "Date of birth"}]}
+/>;
+
+export default Code;

--- a/src/templates/pages/example/tables/row-links/index.js
+++ b/src/templates/pages/example/tables/row-links/index.js
@@ -1,0 +1,13 @@
+import { h } from 'preact';
+import ExampleLayout from '@layouts/example';
+import Code from './code';
+
+export const title = 'Table example with row links';
+
+const TableRowLinks = () => <ExampleLayout>
+    <main class="soft-top soft-sides">
+        <Code />
+    </main>
+</ExampleLayout>;
+
+export default TableRowLinks;

--- a/src/templates/pages/example/tables/row-links/index.js
+++ b/src/templates/pages/example/tables/row-links/index.js
@@ -3,6 +3,7 @@ import ExampleLayout from '@layouts/example';
 import Code from './code';
 
 export const title = 'Table example with row links';
+export const bodyClass = 'example-body';
 
 const TableRowLinks = () => <ExampleLayout>
     <main class="soft-top soft-sides">

--- a/src/templates/pages/example/tabs/index.js
+++ b/src/templates/pages/example/tabs/index.js
@@ -3,6 +3,7 @@ import ExampleLayout from '@layouts/example';
 import Code from './code';
 
 export const title = 'Tabs example';
+export const bodyClass = 'example-body';
 
 const Tabs = () => <ExampleLayout>
     <main>

--- a/src/templates/pages/index.js
+++ b/src/templates/pages/index.js
@@ -38,7 +38,7 @@ const PATTERNS = [
 	// { title: 'Modal gallery', url: '/patterns/modal-gallery' },
 	{ title: "Modal search", url: "/patterns/modal-search", status: modalSearchStatus },
 	{ title: "Table with scrolling overflow", url: "/patterns/table-overflow", status: tablesOverflowStatus },
-	{ title: "Table with responsive layout", url: "/patterns/table-responsive", status: tablesResponsiveStatus },
+	{ title: "Table with responsive card layout", url: "/patterns/table-responsive", status: tablesResponsiveStatus },
 	{ title: "Table with linked rows", url: "/patterns/table-row-links", status: tablesRowLinksStatus },
 	{ title: "Tabs", url: "/patterns/tabs", status: tabsStatus },
 ];

--- a/src/templates/pages/index.js
+++ b/src/templates/pages/index.js
@@ -13,6 +13,9 @@ import { status as tabsStatus } from "./patterns/tabs";
 import { status as formValidationStatus } from "./patterns/form-validation";
 import { status as formHeadingStatus } from "./patterns/form-headings";
 import { status as headingSubheadingStatus } from "./patterns/heading-subheading";
+import { status as tablesOverflowStatus } from "./patterns/table-overflow";
+import { status as tablesResponsiveStatus } from "./patterns/table-responsive";
+import { status as tablesRowLinksStatus } from "./patterns/table-row-links";
 
 export const title = "Home";
 
@@ -34,13 +37,16 @@ const PATTERNS = [
 	{ title: "Modal confirmation", url: "/patterns/modal-confirmation", status: modalConfirmationStatus },
 	// { title: 'Modal gallery', url: '/patterns/modal-gallery' },
 	{ title: "Modal search", url: "/patterns/modal-search", status: modalSearchStatus },
+	{ title: "Table with scrolling overflow", url: "/patterns/table-overflow", status: tablesOverflowStatus },
+	{ title: "Table with responsive layout", url: "/patterns/table-responsive", status: tablesResponsiveStatus },
+	{ title: "Table with linked rows", url: "/patterns/table-row-links", status: tablesRowLinksStatus },
 	{ title: "Tabs", url: "/patterns/tabs", status: tabsStatus },
 ];
 
 const HomePage = () => (
 	<DefaultLayout>
 		<div class="wrap">
-			<div class="table__container push-bottom">
+			<div class="table__container--base push-bottom">
 				<table class="table">
 					<thead>
 						<tr>

--- a/src/templates/pages/patterns/table-overflow/index.js
+++ b/src/templates/pages/patterns/table-overflow/index.js
@@ -1,6 +1,7 @@
 import { h } from 'preact';
 import PatternLayout from '@layouts/pattern';
-import CodeOverflow from '../../example/tables/overflow/code';
+import Code from '../../example/tables/overflow/code';
+import CodeSticky from '../../example/tables/overflow-sticky/code';
 import { render } from 'preact-render-to-string';
 import PatternTitle from '@components/pattern-title';
 import { STATUS } from '@constants';
@@ -20,26 +21,32 @@ const Tables = () => <PatternLayout>
     <p class="push-bottom--double">If this is not necessary, you may want to consider the alterntative <a href="/patterns/table-responsive">responsive table</a> pattern.</p>
     
     <h2 class="push-bottom--half plus-2 medium">Example with scrolling overflow</h2>
-    <iframe style="--height: 375px" class="example" title="Example table with scrolling overflow" src={'/example/tables/overflow'}></iframe>
+    <iframe style="--height: 500px" class="example" title="Example table with scrolling overflow" src={'/example/tables/overflow'}></iframe>
     <p class="push-bottom align-right"><a href="/example/tables/overflow" rel="noopener" target="_blank">Open in a new tab</a></p>
-    <pre class="pre"><code class="code">{`${render(<CodeOverflow />, null, { pretty: true })}`}</code></pre>
+    <pre class="pre"><code class="code">{`${render(<Code />, null, { pretty: true })}`}</code></pre>
+
+    <h2 class="push-bottom--half plus-2 medium">Example with scrolling overflow and sticky column</h2>
+    <iframe style="--height: 500px" class="example" title="Example table with scrolling overflow and sticky column" src={'/example/tables/overflow-sticky'}></iframe>
+    <p class="push-bottom align-right"><a href="/example/tables/overflow-sticky" rel="noopener" target="_blank">Open in a new tab</a></p>
+    <pre class="pre"><code class="code">{`${render(<CodeSticky />, null, { pretty: true })}`}</code></pre>
 
     <h2 class="push-bottom plus-2 medium">Acceptance criteria</h2>
     <p class="push-bottom--double">The following is a list of example acceptance criteria to test against when using this pattern.  These critera should test that the specific markup requirements are met, and that the search behaves visually and functionally as expected.</p>
 
     <h3 class="push-bottom--half plus-1 medium">For validation in developer tools / web inspector</h3>
     <ul class="list list--tick push-bottom--double">
-        <li class="list-item"></li>
+        <li class="list-item">There should be an HTML <pre class="pre--inline">div</pre> element with a container class as the immediate parent of the table</li>
+        <li class="list-item">The container <pre class="pre--inline">div</pre> element should have a <pre class="pre--inline">tabindex="0"</pre> attribute to allow for keyboard access</li>
+        <li class="list-item">The table should contain a <pre class="pre--inline">thead</pre> element which wraps a row containing all <pre class="pre--inline">th</pre> tags</li>
+        <li class="list-item">Each <pre class="pre--inline">th</pre> tag should have an appropriate scope attribute</li>
+        <li class="list-item">The table should contain a <pre class="pre--inline">tbody</pre> element which wraps all subsequent rows</li>
+        <li class="list-item">The table should contain a <pre class="pre--inline">caption</pre> element to summarise the table data</li>
     </ul>
 
     <h3 class="push-bottom--half plus-1 medium">For visual validation</h3>
     <ul class="list list--tick push-bottom--double">
-        <li class="list-item"></li>
-    </ul>
-
-    <h3 class="push-bottom--half plus-1 medium">For functional validation</h3>
-    <ul class="list list--tick push-bottom--double">
-        <li class="list-item"></li>
+        <li class="list-item">At mobile breakpoints, the table rows and cells should convert to vertically stacked cards</li>
+        <li class="list-item">Appropriate headings should be visible above each data element</li>
     </ul>
 
     <h2 class="push-bottom--half plus-1 medium">References</h2>

--- a/src/templates/pages/patterns/table-overflow/index.js
+++ b/src/templates/pages/patterns/table-overflow/index.js
@@ -11,12 +11,13 @@ export const status = STATUS.DEVELOPMENT;
 
 const Tables = () => <PatternLayout>
     <PatternTitle status={status}>Table with scrolling overflow</PatternTitle>
-    <p class="push-bottom--double"></p>
+    <p class="push-bottom--double">An example of markup and styling for a scrollable table wrapper</p>
     
     <h2 class="push-bottom--half plus-2 medium">Guidance</h2>
-    <p class="push-bottom"></p>
-    <p class="push-bottom--double"></p>
-
+    <p class="push-bottom">Tabular data can be difficult to display at smaller breakpoints.  The reduced width of mobile screens does not allow space for table rows to stretch out and data can end up looking very compressed, or cutting off on the right of the screen.</p>
+    <p class="push-bottom">One option to handle this is to wrap the table in a container. This container is styled to scroll horizontally when it needs to, while keeping the rest of the page contained within the screen width.</p>
+    <p class="push-bottom">This pattern is best used when the tabular data needs to be scanned by the user in the context of the other rows around it.  It allows for easier visual comparison between table entries.</p>
+    <p class="push-bottom--double">If this is not necessary, you may want to consider the alterntative <a href="/patterns/table-responsive">responsive table</a> pattern.</p>
     
     <h2 class="push-bottom--half plus-2 medium">Example with scrolling overflow</h2>
     <iframe style="--height: 375px" class="example" title="Example table with scrolling overflow" src={'/example/tables/overflow'}></iframe>

--- a/src/templates/pages/patterns/table-overflow/index.js
+++ b/src/templates/pages/patterns/table-overflow/index.js
@@ -1,0 +1,50 @@
+import { h } from 'preact';
+import PatternLayout from '@layouts/pattern';
+import CodeOverflow from '../../example/tables/overflow/code';
+import { render } from 'preact-render-to-string';
+import PatternTitle from '@components/pattern-title';
+import { STATUS } from '@constants';
+
+export const title = 'Table patterns';
+
+export const status = STATUS.DEVELOPMENT;
+
+const Tables = () => <PatternLayout>
+    <PatternTitle status={status}>Table with scrolling overflow</PatternTitle>
+    <p class="push-bottom--double"></p>
+    
+    <h2 class="push-bottom--half plus-2 medium">Guidance</h2>
+    <p class="push-bottom"></p>
+    <p class="push-bottom--double"></p>
+
+    
+    <h2 class="push-bottom--half plus-2 medium">Example with scrolling overflow</h2>
+    <iframe style="--height: 375px" class="example" title="Example table with scrolling overflow" src={'/example/tables/overflow'}></iframe>
+    <p class="push-bottom align-right"><a href="/example/tables/overflow" rel="noopener" target="_blank">Open in a new tab</a></p>
+    <pre class="pre"><code class="code">{`${render(<CodeOverflow />, null, { pretty: true })}`}</code></pre>
+
+    <h2 class="push-bottom plus-2 medium">Acceptance criteria</h2>
+    <p class="push-bottom--double">The following is a list of example acceptance criteria to test against when using this pattern.  These critera should test that the specific markup requirements are met, and that the search behaves visually and functionally as expected.</p>
+
+    <h3 class="push-bottom--half plus-1 medium">For validation in developer tools / web inspector</h3>
+    <ul class="list list--tick push-bottom--double">
+        <li class="list-item"></li>
+    </ul>
+
+    <h3 class="push-bottom--half plus-1 medium">For visual validation</h3>
+    <ul class="list list--tick push-bottom--double">
+        <li class="list-item"></li>
+    </ul>
+
+    <h3 class="push-bottom--half plus-1 medium">For functional validation</h3>
+    <ul class="list list--tick push-bottom--double">
+        <li class="list-item"></li>
+    </ul>
+
+    <h2 class="push-bottom--half plus-1 medium">References</h2>
+    <ul class="list push-bottom--double">
+        <li class="list-item"></li>
+    </ul>
+</PatternLayout>;
+
+export default Tables;

--- a/src/templates/pages/patterns/table-overflow/index.js
+++ b/src/templates/pages/patterns/table-overflow/index.js
@@ -15,10 +15,10 @@ const Tables = () => <PatternLayout>
     <p class="push-bottom--double">An example of markup and styling for a scrollable table wrapper</p>
     
     <h2 class="push-bottom--half plus-2 medium">Guidance</h2>
-    <p class="push-bottom">Tabular data can be difficult to display at smaller breakpoints.  The reduced width of mobile screens does not allow space for table rows to stretch out and data can end up looking very compressed, or cutting off on the right of the screen.</p>
+    <p class="push-bottom">Tabular data can be difficult to display at smaller breakpoints.  The reduced width of mobile screens does not allow space for table rows to stretch out and data can end up looking very compressed, or cutting off to the right of the screen.</p>
     <p class="push-bottom">One option to handle this is to wrap the table in a container. This container is styled to scroll horizontally when it needs to, while keeping the rest of the page contained within the screen width.</p>
-    <p class="push-bottom">This pattern is best used when the tabular data needs to be scanned by the user in the context of the other rows around it.  It allows for easier visual comparison between table entries.</p>
-    <p class="push-bottom--double">If this is not necessary, you may want to consider the alterntative <a href="/patterns/table-responsive">responsive table</a> pattern.</p>
+    <p class="push-bottom">This pattern is best used when the tabular data needs to be scanned by the user in the context of the other rows around it.  It allows for easier visual comparison between table row entries.</p>
+    <p class="push-bottom--double">If this is not necessary, you may wish to consider the alterntative <a href="/patterns/table-responsive">responsive card table</a> pattern.</p>
     
     <h2 class="push-bottom--half plus-2 medium">Example with scrolling overflow</h2>
     <iframe style="--height: 500px" class="example" title="Example table with scrolling overflow" src={'/example/tables/overflow'}></iframe>
@@ -35,20 +35,20 @@ const Tables = () => <PatternLayout>
 
     <h3 class="push-bottom--half plus-1 medium">For validation in developer tools / web inspector</h3>
     <ul class="list list--tick push-bottom--double">
-        <li class="list-item">There should be an HTML <pre class="pre--inline">div</pre> element with a container class as the immediate parent of the table</li>
-        <li class="list-item">The container <pre class="pre--inline">div</pre> element should have a <pre class="pre--inline">tabindex="0"</pre> attribute to allow for keyboard access</li>
-        <li class="list-item">The container <pre class="pre--inline">div</pre> element should have an <pre class="pre--inline">aria-describedby</pre> attribute which matches the id of the table caption</li>
-        <li class="list-item">The table should contain a <pre class="pre--inline">&lt;thead&gt;</pre> element which wraps a row containing all <pre class="pre--inline">&lt;th&gt;</pre> tags</li>
+        <li class="list-item">There should be an HTML <pre class="pre--inline">&lt;div&gt;</pre> element with a container class as the immediate parent of the table</li>
+        <li class="list-item">The container <pre class="pre--inline">&lt;div&gt;</pre> element should have a <pre class="pre--inline">tabindex="0"</pre> attribute to allow for keyboard access</li>
+        <li class="list-item">The container <pre class="pre--inline">div</pre> element should have an <pre class="pre--inline">aria-labelledby</pre> attribute which matches the id of the table caption</li>
+        <li class="list-item">The table should contain a <pre class="pre--inline">&lt;thead&gt;</pre> element which wraps a row containing <pre class="pre--inline">&lt;th&gt;</pre> tags</li>
         <li class="list-item">Each <pre class="pre--inline">&lt;th&gt;</pre> tag should have an appropriate scope attribute</li>
         <li class="list-item">The table should contain a <pre class="pre--inline">&lt;tbody&gt;</pre> element which wraps all subsequent rows</li>
-        <li class="list-item">The table should contain a <pre class="pre--inline">&lt;caption&gt;</pre> element to summarise the table data</li>
-        <li class="list-item">The <pre class="pre--inline">&lt;caption&gt;</pre> element should have an id which matches the <pre class="pre--inline">aria-describedby</pre> attribute on the scrollable container</li>
+        <li class="list-item">The table should contain a <pre class="pre--inline">&lt;caption&gt;</pre> element to summarise the and title the table</li>
+        <li class="list-item">The <pre class="pre--inline">&lt;caption&gt;</pre> element should have an id which matches the <pre class="pre--inline">aria-labelledby</pre> attribute on the scrollable container</li>
     </ul>
 
     <h3 class="push-bottom--half plus-1 medium">For visual validation</h3>
     <ul class="list list--tick push-bottom--double">
-        <li class="list-item">At mobile breakpoints the table cells should continue to have a comfortable amount of whitespace</li>
-        <li class="list-item">At mobile breakpoints the table container should have a visual indication that the area is scrollable, such as a shadow, scrollbar or icon</li>
+        <li class="list-item">At mobile breakpoints the table cells should continue to have a comfortable amount of whitespace and not become too compressed</li>
+        <li class="list-item">At mobile breakpoints the table container should have some visual indication that the area is scrollable, such as a scrollbar, shadow or icon</li>
     </ul>
 
     <h2 class="push-bottom--half plus-1 medium">References</h2>

--- a/src/templates/pages/patterns/table-overflow/index.js
+++ b/src/templates/pages/patterns/table-overflow/index.js
@@ -37,21 +37,26 @@ const Tables = () => <PatternLayout>
     <ul class="list list--tick push-bottom--double">
         <li class="list-item">There should be an HTML <pre class="pre--inline">div</pre> element with a container class as the immediate parent of the table</li>
         <li class="list-item">The container <pre class="pre--inline">div</pre> element should have a <pre class="pre--inline">tabindex="0"</pre> attribute to allow for keyboard access</li>
-        <li class="list-item">The table should contain a <pre class="pre--inline">thead</pre> element which wraps a row containing all <pre class="pre--inline">th</pre> tags</li>
-        <li class="list-item">Each <pre class="pre--inline">th</pre> tag should have an appropriate scope attribute</li>
-        <li class="list-item">The table should contain a <pre class="pre--inline">tbody</pre> element which wraps all subsequent rows</li>
-        <li class="list-item">The table should contain a <pre class="pre--inline">caption</pre> element to summarise the table data</li>
+        <li class="list-item">The container <pre class="pre--inline">div</pre> element should have an <pre class="pre--inline">aria-describedby</pre> attribute which matches the id of the table caption</li>
+        <li class="list-item">The table should contain a <pre class="pre--inline">&lt;thead&gt;</pre> element which wraps a row containing all <pre class="pre--inline">&lt;th&gt;</pre> tags</li>
+        <li class="list-item">Each <pre class="pre--inline">&lt;th&gt;</pre> tag should have an appropriate scope attribute</li>
+        <li class="list-item">The table should contain a <pre class="pre--inline">&lt;tbody&gt;</pre> element which wraps all subsequent rows</li>
+        <li class="list-item">The table should contain a <pre class="pre--inline">&lt;caption&gt;</pre> element to summarise the table data</li>
+        <li class="list-item">The <pre class="pre--inline">&lt;caption&gt;</pre> element should have an id which matches the <pre class="pre--inline">aria-describedby</pre> attribute on the scrollable container</li>
     </ul>
 
     <h3 class="push-bottom--half plus-1 medium">For visual validation</h3>
     <ul class="list list--tick push-bottom--double">
-        <li class="list-item">At mobile breakpoints, the table rows and cells should convert to vertically stacked cards</li>
-        <li class="list-item">Appropriate headings should be visible above each data element</li>
+        <li class="list-item">At mobile breakpoints the table cells should continue to have a comfortable amount of whitespace</li>
+        <li class="list-item">At mobile breakpoints the table container should have a visual indication that the area is scrollable, such as a shadow, scrollbar or icon</li>
     </ul>
 
     <h2 class="push-bottom--half plus-1 medium">References</h2>
     <ul class="list push-bottom--double">
-        <li class="list-item"></li>
+        <li class="list-item"><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table" rel="noopener nofollow">https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table</a></li>
+        <li class="list-item"><a href="https://www.w3.org/WAI/tutorials/tables/" rel="noopener nofollow">https://www.w3.org/WAI/tutorials/tables/</a></li>
+        <li class="list-item"><a href="https://www.w3.org/WAI/standards-guidelines/act/rules/0ssw9k/" rel="noopener nofollow">https://www.w3.org/WAI/standards-guidelines/act/rules/0ssw9k/</a></li>
+        <li class="list-item"><a href="https://design-system.w3.org/styles/tables.html#responsive-tables" rel="noopener nofollow">https://design-system.w3.org/styles/tables.html#responsive-tables</a></li>
     </ul>
 </PatternLayout>;
 

--- a/src/templates/pages/patterns/table-responsive/index.js
+++ b/src/templates/pages/patterns/table-responsive/index.js
@@ -10,12 +10,14 @@ export const title = 'Table patterns';
 export const status = STATUS.DEVELOPMENT;
 
 const Tables = () => <PatternLayout>
-    <PatternTitle status={status}>Table with responsive layout</PatternTitle>
-    <p class="push-bottom--double"></p>
+    <PatternTitle status={status}>Table with responsive card layout</PatternTitle>
+    <p class="push-bottom--double">An example of how to convert table rows to data cards for smaller devices</p>
     
     <h2 class="push-bottom--half plus-2 medium">Guidance</h2>
-    <p class="push-bottom"></p>
-    <p class="push-bottom--double"></p>
+    <p class="push-bottom">Tabular data can be difficult to display at smaller breakpoints.  The reduced width of mobile screens does not allow space for table rows to stretch out and data can end up looking very compressed, or cutting off on the right of the screen.</p>
+    <p class="push-bottom">One option to handle this is to convert the table rows to data cards for smaller devices.  When the correct breakpoint is hit, each table row is displayed as a card instead with the matching table headers being placed appropriately using the CSS 'content' property.</p>
+    <p class="push-bottom">This pattern is good for displaying data without the user having to scroll horizontally - something that isn't naturally instinctive for a user to do.  It also allows for more of the data entry to be visible on screen at one time, as the vertical space is almost always much larger on a handheld device.</p>
+    <p class="push-bottom--double">This pattern only works in a use case where the user does not need to scan a table and make direct visual comparison between the rows. If this is a requirement, you should consider the alterntative <a href="/patterns/table-overflow">overflow table</a> pattern.</p>
 
     <h2 class="push-bottom--half plus-2 medium">Example responsive table</h2>
     <iframe style="--height: 375px" class="example" title="Example responsive table" src={'/example/tables/responsive'}></iframe>

--- a/src/templates/pages/patterns/table-responsive/index.js
+++ b/src/templates/pages/patterns/table-responsive/index.js
@@ -29,7 +29,10 @@ const Tables = () => <PatternLayout>
 
     <h3 class="push-bottom--half plus-1 medium">For validation in developer tools / web inspector</h3>
     <ul class="list list--tick push-bottom--double">
-        <li class="list-item"></li>
+        <li class="list-item">The table should contain a <pre class="pre--inline">thead</pre> element which wraps a row containing all <pre class="pre--inline">th</pre> tags</li>
+        <li class="list-item">Each <pre class="pre--inline">th</pre> tag should have an appropriate scope attribute</li>
+        <li class="list-item">The table should contain a <pre class="pre--inline">tbody</pre> element which wraps all subsequent rows</li>
+        <li class="list-item">The table should contain a <pre class="pre--inline">caption</pre> element to summarise the table data</li>
     </ul>
 
     <h3 class="push-bottom--half plus-1 medium">For visual validation</h3>

--- a/src/templates/pages/patterns/table-responsive/index.js
+++ b/src/templates/pages/patterns/table-responsive/index.js
@@ -14,7 +14,7 @@ const Tables = () => <PatternLayout>
     <p class="push-bottom--double">An example of how to convert table rows to data cards for smaller devices</p>
     
     <h2 class="push-bottom--half plus-2 medium">Guidance</h2>
-    <p class="push-bottom">Tabular data can be difficult to display at smaller breakpoints.  The reduced width of mobile screens does not allow space for table rows to stretch out and data can end up looking very compressed, or cutting off on the right of the screen.</p>
+    <p class="push-bottom">Tabular data can be difficult to display at smaller breakpoints.  The reduced width of mobile screens does not allow space for table rows to stretch out and data can end up looking very compressed, or cutting off to the right of the screen.</p>
     <p class="push-bottom">One option to handle this is to convert the table rows to data cards for smaller devices.  When the correct breakpoint is hit, each table row is displayed as a card instead with the matching table headers being placed appropriately using the CSS 'content' property.</p>
     <p class="push-bottom">This pattern is good for displaying data without the user having to scroll horizontally - something that isn't naturally instinctive for a user to do.  It also allows for more of the data entry to be visible on screen at one time, as the vertical space is almost always much larger on a handheld device.</p>
     <p class="push-bottom--double">This pattern only works in a use case where the user does not need to scan a table and make direct visual comparison between the rows. If this is a requirement, you should consider the alterntative <a href="/patterns/table-overflow">overflow table</a> pattern.</p>
@@ -29,10 +29,10 @@ const Tables = () => <PatternLayout>
 
     <h3 class="push-bottom--half plus-1 medium">For validation in developer tools / web inspector</h3>
     <ul class="list list--tick push-bottom--double">
-        <li class="list-item">The table should contain a <pre class="pre--inline">thead</pre> element which wraps a row containing all <pre class="pre--inline">th</pre> tags</li>
+        <li class="list-item">The table should contain a <pre class="pre--inline">&lt;thead&gt;</pre> element which wraps a row containing all <pre class="pre--inline">&lt;th&gt;</pre> tags</li>
         <li class="list-item">Each <pre class="pre--inline">th</pre> tag should have an appropriate scope attribute</li>
-        <li class="list-item">The table should contain a <pre class="pre--inline">tbody</pre> element which wraps all subsequent rows</li>
-        <li class="list-item">The table should contain a <pre class="pre--inline">caption</pre> element to summarise the table data</li>
+        <li class="list-item">The table should contain a <pre class="pre--inline">&lt;tbody&gt;</pre> element which wraps all subsequent rows</li>
+        <li class="list-item">The table should contain a <pre class="pre--inline">&lt;caption&gt;</pre> element to summarise the table data</li>
     </ul>
 
     <h3 class="push-bottom--half plus-1 medium">For visual validation</h3>
@@ -43,13 +43,14 @@ const Tables = () => <PatternLayout>
 
     <h3 class="push-bottom--half plus-1 medium">For functional validation</h3>
     <ul class="list list--tick push-bottom--double">
-        <li class="list-item">When using a screenreader, the table should not be surfaced any differently between layouts.  The markup should still be available to all table based navigation methods and shortcuts</li>
+        <li class="list-item">When using a screenreader, the table should not be surfaced differently between breakpoints.  The markup should still be available to all table based navigation methods and keyboard shortcuts</li>
     </ul>
 
     <h2 class="push-bottom--half plus-1 medium">References</h2>
     <ul class="list push-bottom--double">
         <li class="list-item"><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table" rel="noopener nofollow">https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table</a></li>
         <li class="list-item"><a href="https://www.w3.org/WAI/tutorials/tables/" rel="noopener nofollow">https://www.w3.org/WAI/tutorials/tables/</a></li>
+        <li class="list-item"><a href="https://adrianroselli.com/2022/07/its-mid-2022-and-browsers-mostly-safari-still-break-accessibility-via-display-properties.html" rel="noopener nofollow">https://adrianroselli.com/2022/07/its-mid-2022-and-browsers-mostly-safari-still-break-accessibility-via-display-properties.html</a></li>
     </ul>
 </PatternLayout>;
 

--- a/src/templates/pages/patterns/table-responsive/index.js
+++ b/src/templates/pages/patterns/table-responsive/index.js
@@ -37,17 +37,19 @@ const Tables = () => <PatternLayout>
 
     <h3 class="push-bottom--half plus-1 medium">For visual validation</h3>
     <ul class="list list--tick push-bottom--double">
-        <li class="list-item"></li>
+        <li class="list-item">At mobile breakpoints, the table rows and cells should convert to vertically stacked cards</li>
+        <li class="list-item">Appropriate headings should be visible above each data element</li>
     </ul>
 
     <h3 class="push-bottom--half plus-1 medium">For functional validation</h3>
     <ul class="list list--tick push-bottom--double">
-        <li class="list-item"></li>
+        <li class="list-item">When using a screenreader, the table should not be surfaced any differently between layouts.  The markup should still be available to all table based navigation methods and shortcuts</li>
     </ul>
 
     <h2 class="push-bottom--half plus-1 medium">References</h2>
     <ul class="list push-bottom--double">
-        <li class="list-item"></li>
+        <li class="list-item"><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table" rel="noopener nofollow">https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table</a></li>
+        <li class="list-item"><a href="https://www.w3.org/WAI/tutorials/tables/" rel="noopener nofollow">https://www.w3.org/WAI/tutorials/tables/</a></li>
     </ul>
 </PatternLayout>;
 

--- a/src/templates/pages/patterns/table-responsive/index.js
+++ b/src/templates/pages/patterns/table-responsive/index.js
@@ -1,0 +1,49 @@
+import { h } from 'preact';
+import PatternLayout from '@layouts/pattern';
+import CodeResponsive from '../../example/tables/responsive/code';
+import { render } from 'preact-render-to-string';
+import PatternTitle from '@components/pattern-title';
+import { STATUS } from '@constants';
+
+export const title = 'Table patterns';
+
+export const status = STATUS.DEVELOPMENT;
+
+const Tables = () => <PatternLayout>
+    <PatternTitle status={status}>Table with responsive layout</PatternTitle>
+    <p class="push-bottom--double"></p>
+    
+    <h2 class="push-bottom--half plus-2 medium">Guidance</h2>
+    <p class="push-bottom"></p>
+    <p class="push-bottom--double"></p>
+
+    <h2 class="push-bottom--half plus-2 medium">Example responsive table</h2>
+    <iframe style="--height: 375px" class="example" title="Example responsive table" src={'/example/tables/responsive'}></iframe>
+    <p class="push-bottom align-right"><a href="/example/tables/responsive" rel="noopener" target="_blank">Open in a new tab</a></p>
+    <pre class="pre"><code class="code">{`${render(<CodeResponsive />, null, { pretty: true })}`}</code></pre>
+
+    <h2 class="push-bottom plus-2 medium">Acceptance criteria</h2>
+    <p class="push-bottom--double">The following is a list of example acceptance criteria to test against when using this pattern.  These critera should test that the specific markup requirements are met, and that the search behaves visually and functionally as expected.</p>
+
+    <h3 class="push-bottom--half plus-1 medium">For validation in developer tools / web inspector</h3>
+    <ul class="list list--tick push-bottom--double">
+        <li class="list-item"></li>
+    </ul>
+
+    <h3 class="push-bottom--half plus-1 medium">For visual validation</h3>
+    <ul class="list list--tick push-bottom--double">
+        <li class="list-item"></li>
+    </ul>
+
+    <h3 class="push-bottom--half plus-1 medium">For functional validation</h3>
+    <ul class="list list--tick push-bottom--double">
+        <li class="list-item"></li>
+    </ul>
+
+    <h2 class="push-bottom--half plus-1 medium">References</h2>
+    <ul class="list push-bottom--double">
+        <li class="list-item"></li>
+    </ul>
+</PatternLayout>;
+
+export default Tables;

--- a/src/templates/pages/patterns/table-row-links/index.js
+++ b/src/templates/pages/patterns/table-row-links/index.js
@@ -1,0 +1,50 @@
+import { h } from 'preact';
+import PatternLayout from '@layouts/pattern';
+import CodeRowLinks from '../../example/tables/row-links/code';
+import { render } from 'preact-render-to-string';
+import PatternTitle from '@components/pattern-title';
+import { STATUS } from '@constants';
+
+export const title = 'Table patterns';
+
+export const status = STATUS.DEVELOPMENT;
+
+const Tables = () => <PatternLayout>
+    <PatternTitle status={status}>Table with linked rows</PatternTitle>
+    <p class="push-bottom--double"></p>
+    
+    <h2 class="push-bottom--half plus-2 medium">Guidance</h2>
+    <p class="push-bottom"></p>
+    <p class="push-bottom--double"></p>
+
+    <h2 class="push-bottom--half plus-2 medium">Example with linked rows</h2>
+    <iframe style="--height: 375px" class="example" title="Example table with row links" src={'/example/tables/row-links'}></iframe>
+    <p class="push-bottom align-right"><a href="/example/tables/row-links" rel="noopener" target="_blank">Open in a new tab</a></p>
+    <pre class="pre"><code class="code">{`${render(<CodeRowLinks />, null, { pretty: true })}`}</code></pre>
+
+
+    <h2 class="push-bottom plus-2 medium">Acceptance criteria</h2>
+    <p class="push-bottom--double">The following is a list of example acceptance criteria to test against when using this pattern.  These critera should test that the specific markup requirements are met, and that the search behaves visually and functionally as expected.</p>
+
+    <h3 class="push-bottom--half plus-1 medium">For validation in developer tools / web inspector</h3>
+    <ul class="list list--tick push-bottom--double">
+        <li class="list-item"></li>
+    </ul>
+
+    <h3 class="push-bottom--half plus-1 medium">For visual validation</h3>
+    <ul class="list list--tick push-bottom--double">
+        <li class="list-item"></li>
+    </ul>
+
+    <h3 class="push-bottom--half plus-1 medium">For functional validation</h3>
+    <ul class="list list--tick push-bottom--double">
+        <li class="list-item"></li>
+    </ul>
+
+    <h2 class="push-bottom--half plus-1 medium">References</h2>
+    <ul class="list push-bottom--double">
+        <li class="list-item"></li>
+    </ul>
+</PatternLayout>;
+
+export default Tables;

--- a/src/templates/pages/patterns/table-row-links/index.js
+++ b/src/templates/pages/patterns/table-row-links/index.js
@@ -14,8 +14,8 @@ const Tables = () => <PatternLayout>
     <p class="push-bottom--double"></p>
     
     <h2 class="push-bottom--half plus-2 medium">Guidance</h2>
-    <p class="push-bottom"></p>
-    <p class="push-bottom--double"></p>
+    <p class="push-bottom">Tables are a useful pattern for summarising a list of data, and sometimes it is necessary for each entry to link onwards to further details.</p>
+    <p class="push-bottom--double">This pattern shows a way to mark up the table when the design requires the whole table row to be linked, rather than a single cell.</p>
 
     <h2 class="push-bottom--half plus-2 medium">Example with linked rows</h2>
     <iframe style="--height: 375px" class="example" title="Example table with row links" src={'/example/tables/row-links'}></iframe>
@@ -28,22 +28,30 @@ const Tables = () => <PatternLayout>
 
     <h3 class="push-bottom--half plus-1 medium">For validation in developer tools / web inspector</h3>
     <ul class="list list--tick push-bottom--double">
-        <li class="list-item"></li>
+        <li class="list-item">The table should contain a <pre class="pre--inline">thead</pre> element which wraps a row containing all <pre class="pre--inline">th</pre> tags</li>
+        <li class="list-item">Each <pre class="pre--inline">&lt;th&gt;</pre> tag should have an appropriate scope attribute</li>
+        <li class="list-item">The table should contain a <pre class="pre--inline">&lt;tbody&gt;</pre> element which wraps all subsequent rows</li>
+        <li class="list-item">The table should contain a <pre class="pre--inline">&lt;caption&gt;</pre> element to summarise the table data</li>
+        <li class="list-item">Each table row should contain only one <pre class="pre--inline">&lt;a&gt;</pre> tag</li>
+        <li class="list-item">The <pre class="pre--inline">&lt;a&gt;</pre> tag should be within the last cell and should be accessibly labelled</li>
     </ul>
 
     <h3 class="push-bottom--half plus-1 medium">For visual validation</h3>
     <ul class="list list--tick push-bottom--double">
-        <li class="list-item"></li>
+        <li class="list-item">Visually, the link should appear across the whole table row, with an appropriate hover effect to show that the row is clickable</li>
+        <li class="list-item">A visual focus indicator should appear around the whole table row when the link is activated via the keyboard</li>
     </ul>
 
     <h3 class="push-bottom--half plus-1 medium">For functional validation</h3>
     <ul class="list list--tick push-bottom--double">
-        <li class="list-item"></li>
+        <li class="list-item">The link should be reachable and possible to activate via keyboard</li>
+        <li class="list-item">The link should be read by a screenreader without duplication of content</li>
     </ul>
 
     <h2 class="push-bottom--half plus-1 medium">References</h2>
     <ul class="list push-bottom--double">
-        <li class="list-item"></li>
+        <li class="list-item"><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table" rel="noopener nofollow">https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table</a></li>
+        <li class="list-item"><a href="https://www.w3.org/WAI/tutorials/tables/" rel="noopener nofollow">https://www.w3.org/WAI/tutorials/tables/</a></li>
     </ul>
 </PatternLayout>;
 

--- a/tools/webpack/plugins/default-html.js
+++ b/tools/webpack/plugins/default-html.js
@@ -2,10 +2,11 @@ const h = require('preact').h;
 const Html = require('../../../src/templates/components/html').default;
 const paths = require('../../../paths.config');
 
-const html = ({ htmlBody, css, title, meta }) => <Html
+const html = ({ htmlBody, css, title, meta, bodyClass }) => <Html
     css={css}
     title={title}
     meta={meta}
+    bodyClass={bodyClass}
     basePath={`${process.env.NODE_ENV === 'production' ? `/${paths.dest.js}` : ''}`}
 >
     {htmlBody}

--- a/tools/webpack/plugins/static-entry.js
+++ b/tools/webpack/plugins/static-entry.js
@@ -14,13 +14,14 @@ module.exports = function(locals) {
         const assets = Object.keys(locals.webpackStats.compilation.assets);
         const css = assets.filter(value => value.match(/\.css$/));
         const title = require(`../../../src/templates/pages/${locals.path}`).title || '';
+        const bodyClass = require(`../../../src/templates/pages/${locals.path}`).bodyClass || null;
         const meta = require(`../../../src/templates/pages/${locals.path}`).meta || '';
         return new Promise((resolve, reject) => {
             if (body.then) {
                 body.then(Res => {
-                    resolve(`<!DOCTYPE html>${render(<Html css={css} htmlBody={Res} title={title} meta={meta} />)}`);
+                    resolve(`<!DOCTYPE html>${render(<Html css={css} htmlBody={Res} bodyClass={bodyClass} title={title} meta={meta} />)}`);
                 });
-            } else resolve(`<!DOCTYPE html>${render(<Html css={css} htmlBody={body} title={title} meta={meta} />)}`);
+            } else resolve(`<!DOCTYPE html>${render(<Html css={css} htmlBody={body} bodyClass={bodyClass} title={title} meta={meta} />)}`);
         });
     } catch (e){
         return Promise.reject(`HTML render error: ${e}`);


### PR DESCRIPTION
Addresses #69 

This one ended up covering quite a lot - apologies!

Three new patterns, each with their own page as the use cases were quite separate.

1.  Table with overflow wrapper
2.  Responsive table turns to cards on mobile
3.  Table with linked rows.

When testing on screenreaders, I noticed that there was a problem on the example pages where we had a doubled-up body tag so I addressed that as well to resolve NVDA being confused by that.  So each example page has been touched to add a body class.

Otherwise that pattern seemed to read quite well on NVDA and iOS.  It retained the table navigation and announcements despite all of the significant styling and display changes.